### PR TITLE
Fix mobile canvas rendering for thumbnails and previews

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -510,3 +510,38 @@ embed[type="application/pdf"] .pdfViewer .toolbar {
   opacity: 0 !important;
   pointer-events: none !important;
 }
+
+/* CRITICAL MOBILE CANVAS RENDERING FIXES */
+@media (max-width: 640px) {
+  /* Force ALL canvas elements to render properly on mobile */
+  canvas {
+    width: 100% !important;
+    height: auto !important;
+    max-width: 100%;
+    display: block !important;
+    image-rendering: auto !important;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
+  
+  /* Override Tailwind width classes on canvas */
+  canvas[class*="w-"] {
+    width: 100% !important;
+    height: auto !important;
+  }
+  
+  /* Ensure images render properly */
+  img[alt*="Banner"] {
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+    display: block;
+  }
+  
+  /* Fix flex containers on mobile */
+  .flex-shrink-0 {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
## Critical Mobile Fixes

This PR adds CSS fixes to resolve mobile canvas rendering issues:

### Issues Fixed:
- ✅ Banner preview not displaying on mobile
- ✅ Thumbnails not showing in cart on mobile
- ✅ Thumbnails not showing in checkout on mobile
- ✅ Thumbnails not showing in upsell modal on mobile

### Changes:
- Added mobile-specific CSS media query for canvas elements
- Force canvas to display as block with 100% width on mobile
- Added hardware acceleration transforms for better mobile performance
- Override Tailwind width classes that were preventing canvas display

### Testing:
Test on mobile devices:
1. Design page preview
2. Cart thumbnails
3. Checkout thumbnails
4. Upsell modal thumbnails

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author