### PR TITLE
Fix mobile cart drawer scroll freeze by deferring heavy previews

### DIFF
--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { X, Trash2, Plus, Minus, ShoppingBag, Eye, Tag } from 'lucide-react';
 import BannerPreview from './cart/BannerPreview';
 import ThumbnailPreviewWrapper from './preview/ThumbnailPreviewWrapper';
@@ -53,6 +53,27 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
     [items],
   );
 
+  const [enableHeavyPreviews, setEnableHeavyPreviews] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEnableHeavyPreviews(false);
+      return;
+    }
+
+    const defer = window.requestIdleCallback
+      ? window.requestIdleCallback(() => setEnableHeavyPreviews(true), { timeout: 250 })
+      : window.setTimeout(() => setEnableHeavyPreviews(true), 80);
+
+    return () => {
+      if (typeof defer === "number") {
+        window.clearTimeout(defer);
+      } else {
+        window.cancelIdleCallback?.(defer);
+      }
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleCheckout = () => {
@@ -99,7 +120,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
           </div>
 
           {/* Items */}
-          <div className="flex-1 overflow-y-auto p-6 bg-gray-50">
+          <div className="flex-1 overflow-y-auto p-6 bg-gray-50 [webkit-overflow-scrolling:touch] overscroll-contain touch-pan-y">
             {items.length === 0 ? (
               <div className="text-center py-12">
                 <ShoppingBag className="h-16 w-16 text-gray-300 mx-auto mb-4" />
@@ -145,7 +166,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                             ...(normalized.ropeDisplay ? [{ label: 'Rope', value: normalized.ropeDisplay }] : []),
                             ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                           ]}
-                          largePreview={
+                          renderLargePreview={() => (
                             <BannerPreview
                               widthIn={item.width_in}
                               heightIn={item.height_in}
@@ -163,8 +184,9 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                               isFinalizedSnapshot={!!item.thumbnail_url}
                               maxSize={820}
                             />
-                          }
+                          )}
                         >
+                          {enableHeavyPreviews ? (
                           <BannerPreview
                               key={`thumbnail-${item.id}-${item.text_elements?.length || 0}-${item.image_scale || 1}`}
                               widthIn={item.width_in}
@@ -182,6 +204,9 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                               source={item.source}
                               isFinalizedSnapshot={!!item.thumbnail_url}
                             />
+                          ) : (
+                            <div className="h-[120px] w-[200px] animate-pulse rounded-lg border border-gray-200 bg-gray-100" aria-hidden="true" />
+                          )}
                         </ThumbnailPreviewWrapper>
                       </div>
 

--- a/src/components/preview/ThumbnailPreviewWrapper.tsx
+++ b/src/components/preview/ThumbnailPreviewWrapper.tsx
@@ -23,7 +23,9 @@ export interface ThumbnailPreviewWrapperProps {
   /** Small thumbnail node to display (e.g., <BannerPreview /> at default size). */
   children: React.ReactNode;
   /** Enlarged preview node shown inside the lightbox. */
-  largePreview: React.ReactNode;
+  largePreview?: React.ReactNode;
+  /** Lazy renderer for enlarged preview; preferred to avoid heavy eager work. */
+  renderLargePreview?: () => React.ReactNode;
   /** Optional product title (e.g., "24" x 36" Vinyl Banner"). */
   title?: string;
   /** Optional product details displayed under the enlarged preview. */
@@ -41,6 +43,7 @@ export interface ThumbnailPreviewWrapperProps {
 const ThumbnailPreviewWrapper: React.FC<ThumbnailPreviewWrapperProps> = ({
   children,
   largePreview,
+  renderLargePreview,
   title,
   details,
   className = '',
@@ -98,7 +101,7 @@ const ThumbnailPreviewWrapper: React.FC<ThumbnailPreviewWrapperProps> = ({
         widthIn={widthIn}
         heightIn={heightIn}
       >
-        {largePreview}
+        {renderLargePreview ? renderLargePreview() : largePreview}
       </ProductPreviewLightbox>
     </>
   );


### PR DESCRIPTION
### Motivation
- The cart drawer was eagerly constructing heavy preview trees for each item (thumbnail + enlarged lightbox) on open, which can block the main thread and freeze touch scrolling on mobile. The change aims to make the drawer immediately interactive. 
- Provide a lightweight visual while expensive preview work defers to avoid blocking mobile Safari touch handling.

### Description
- Add a deferred-hydration gate `enableHeavyPreviews` in `src/components/CartModal.tsx` that uses `requestIdleCallback` (with a timeout fallback) to mount expensive preview components only after the drawer is interactive.  
- Show a lightweight skeleton placeholder for each preview slot while previews are deferred so the list is immediately scrollable. 
- Apply mobile/iOS-friendly scrolling helpers on the list container by adding the classes/styles: `-webkit-overflow-scrolling: touch`, `overscroll-contain`, and `touch-pan-y` to the cart items container. 
- Update `src/components/preview/ThumbnailPreviewWrapper.tsx` to accept a lazy `renderLargePreview` renderer so enlarged preview trees are not eagerly constructed on drawer open. 
- Files changed: `src/components/CartModal.tsx`, `src/components/preview/ThumbnailPreviewWrapper.tsx`. 
- This change only affects cart drawer rendering/UX and does not modify pricing, discounts, tax, checkout, PayPal, order creation, or print-file logic.

### Testing
- Ran the production build with `npm run build`, which completed successfully (build succeeded; only pre-existing warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa64c56ba88333844c2b67af2cee8d)