### PR TITLE
Improve mobile cart visibility and builder CTA/step UX (car magnets, quantity)

### DIFF
--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -142,7 +142,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
           {/* Items */}
           <div
             ref={contentRef}
-            className="cart-modal__content flex-1 min-h-0 overflow-y-auto overflow-x-hidden p-6 bg-gray-50 overscroll-contain touch-pan-y"
+            className="cart-modal__content flex-1 min-h-[42dvh] overflow-y-auto overflow-x-hidden p-4 sm:p-6 bg-gray-50 overscroll-contain touch-pan-y"
           >
             {items.length === 0 ? (
               <div className="text-center py-12">
@@ -316,7 +316,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
 
           {/* Footer */}
           {items.length > 0 && (
-            <div className="cart-modal__footer border-t border-gray-200 p-6 space-y-3 bg-white shadow-lg">
+            <div className="cart-modal__footer border-t border-gray-200 p-4 sm:p-6 space-y-2.5 sm:space-y-3 bg-white shadow-lg">
               {/* Dynamic delivery timer — reflects HIT toggle if present */}
               <DeliveryTimer variant="compact" reflectCartSelection />
               <div className="flex justify-between text-gray-700">

--- a/src/index.css
+++ b/src/index.css
@@ -711,6 +711,14 @@ embed[type="application/pdf"] .pdfViewer .toolbar {
     z-index: 1;
     padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
   }
+  @media (max-width: 640px) {
+    .cart-modal__footer {
+      max-height: 48dvh;
+      overflow-y: auto;
+      overscroll-behavior-y: contain;
+      -webkit-overflow-scrolling: touch;
+    }
+  }
 
   html.cart-modal-open,
   body.cart-modal-open {

--- a/src/lib/builderSteps.ts
+++ b/src/lib/builderSteps.ts
@@ -37,6 +37,8 @@ export interface BuilderStepState {
   widthIn: number | null | undefined;
   heightIn: number | null | undefined;
   material: string | null | undefined;
+  /** Set false for products with a single fixed material (e.g. car magnets). */
+  materialRequired?: boolean;
   quantity: number | null | undefined;
   /** Upload lifecycle. */
   isUploading: boolean;
@@ -120,6 +122,7 @@ function isSizeValid(state: BuilderStepState): boolean {
 }
 
 function isMaterialValid(state: BuilderStepState): boolean {
+  if (state.materialRequired === false) return true;
   if (!state.material) return false;
   return state.materialConfirmed !== false;
 }
@@ -146,6 +149,7 @@ function isOptionsComplete(state: BuilderStepState): boolean {
  * Compute the per-step completion bitmap used by the progress indicator.
  */
 export function getProgress(state: BuilderStepState): BuilderProgress {
+  const visibleSteps = BUILDER_STEPS.filter((k) => !(k === 'material' && state.materialRequired === false));
   const completed: Record<BuilderStepKey, boolean> = {
     size: isSizeValid(state),
     material: isMaterialValid(state),
@@ -154,14 +158,14 @@ export function getProgress(state: BuilderStepState): BuilderProgress {
     upload: state.hasUpload,
   };
   // Current step = first incomplete step, or final step if all done.
-  const idx = BUILDER_STEPS.findIndex(k => !completed[k]);
+  const idx = visibleSteps.findIndex(k => !completed[k]);
   const isComplete = idx === -1;
-  const current = isComplete ? BUILDER_STEPS.length : idx + 1;
-  const currentKey = BUILDER_STEPS[Math.min(current - 1, BUILDER_STEPS.length - 1)];
+  const current = isComplete ? visibleSteps.length : idx + 1;
+  const currentKey = visibleSteps[Math.min(current - 1, visibleSteps.length - 1)];
   const label = isComplete ? COMPLETE_PROGRESS_LABEL : STEP_LABELS[currentKey];
   return {
     current,
-    total: BUILDER_STEPS.length,
+    total: visibleSteps.length,
     label,
     completed,
     isComplete,

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -1719,6 +1719,7 @@ const Design: React.FC = () => {
     widthIn,
     heightIn,
     material,
+    materialRequired: !isCarMagnet,
     quantity,
     isUploading,
     uploadError: uploadError || null,
@@ -1728,7 +1729,7 @@ const Design: React.FC = () => {
     materialConfirmed: hasConfirmedMaterial,
     quantityConfirmed: hasConfirmedQuantity,
     optionsReviewed: hasReviewedOptions,
-  }), [showEntryCta, widthIn, heightIn, material, quantity, isUploading, uploadError, uploadedFile, hasConfirmedSize, hasConfirmedMaterial, hasConfirmedQuantity, hasReviewedOptions]);
+  }), [showEntryCta, widthIn, heightIn, material, isCarMagnet, quantity, isUploading, uploadError, uploadedFile, hasConfirmedSize, hasConfirmedMaterial, hasConfirmedQuantity, hasReviewedOptions]);
 
   const builderProgress = useMemo(() => getProgress(builderState), [builderState]);
 
@@ -2283,6 +2284,7 @@ const Design: React.FC = () => {
                   )}
                 </div>
               </ConfigCard>
+              {!isCarMagnet && (
               <ConfigCard step={2} title="Select material" id="material-section">
                 <div ref={materialDropdownRef} className="relative">
                   {isCarMagnet ? (
@@ -2339,7 +2341,8 @@ const Design: React.FC = () => {
                   )}
                 </div>
               </ConfigCard>
-              <ConfigCard step={3} title="Quantity" id="quantity-section">
+              )}
+              <ConfigCard step={isCarMagnet ? 2 : 3} title="Quantity" id="quantity-section">
                 <div className="flex items-center gap-3">
                   <button onClick={() => setQuantity(q => Math.max(1, q - 1))} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
                     <Minus className="h-4 w-4 text-gray-600" />
@@ -2354,11 +2357,14 @@ const Design: React.FC = () => {
                     🎉 {Math.round(quantityDiscountRate * 100)}% bulk discount applied at checkout
                   </p>
                 )}
+                {quantity === 1 && (
+                  <p className="text-xs text-gray-500 mt-1.5">Quantity 1 selected — continue when ready.</p>
+                )}
                 {!isCarMagnet && quantity === 1 && (
-                  <p className="text-xs text-gray-400 mt-1.5">Order 2+ for up to 13% off</p>
+                  <p className="text-xs text-gray-400 mt-1">Order 2+ for up to 13% off</p>
                 )}
               </ConfigCard>
-              <ConfigCard step={4} title={isCarMagnet ? 'Rounded Corners' : 'Finishing options'} id="options-section">
+              <ConfigCard step={isCarMagnet ? 3 : 4} title={isCarMagnet ? 'Rounded Corners' : 'Finishing options'} id="options-section">
                 <div className="space-y-3">
                   {isCarMagnet ? (
                     <div>
@@ -2382,7 +2388,7 @@ const Design: React.FC = () => {
                   )}
                 </div>
               </ConfigCard>
-              <ConfigCard step={5} title="Upload your artwork" id="upload-section">
+              <ConfigCard step={isCarMagnet ? 4 : 5} title="Upload your artwork" id="upload-section">
                 {/* Helper banner: shown when the user reaches the upload card before
                     completing required choices. Doesn't block upload (per spec) — just
                     surfaces what still needs to happen before "Add to Cart" works. */}


### PR DESCRIPTION
### Motivation
- Mobile cart drawer top item was being visually crushed by the order summary/footer on open, making the first item hard to see; the layout needs a safer mobile-first arrangement that preserves delivery messaging and the checkout CTA. 
- Product builder sticky CTA/step numbers must reflect the true required choices per product (banners, yard signs, car magnets) so users always see the correct next action. 
- Minimize friction by hiding or de-emphasizing material selection where a product only has one material and make default quantity choices feel clearly valid.

### Description
- Gave the cart item list a guaranteed visible area on mobile by setting a mobile-first minimum height on the scrollable content in `src/components/CartModal.tsx` (`min-h-[42dvh]`) and tightened mobile footer spacing to avoid crushing the product list. 
- Made the cart footer scrollable on small screens by adding mobile-only `max-height` and `overflow-y`/touch-scrolling rules to `.cart-modal__footer` in `src/index.css` so delivery/totals/CTA remain accessible without hiding product cards. 
- Extended the builder step machine with `materialRequired?: boolean` in `src/lib/builderSteps.ts` so the `material` step auto-passes when not required and progress/step counts dynamically exclude the material step. 
- Wired the shared builder state in `src/pages/Design.tsx` to pass `materialRequired: !isCarMagnet`, removed the material selection card for car magnets on `/design`, and adjusted subsequent step numbering so Quantity/Options/Upload become steps `2/3/4` for car magnets. 
- Improved quantity UX by showing a helper message when the default `quantity === 1` is already valid (`Quantity 1 selected — continue when ready.`) so users don’t feel they must re-tap the quantity control. 
- Preserved constraints: no changes to pricing formulas, checkout/PayPal/order creation, print/export/render pipeline, or quick-quote carryover logic (only UI/step-flow behavior changed). 

### Testing
- Ran a production build with `npm run build`, which completed successfully (build artifacts generated) and verified the application compiles after fixes. 
- Build emitted non-blocking warnings (Browserslist update notice, ambiguous Tailwind utility warning, and CSS minifier warnings) but these did not prevent a successful build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa88bf21c88333b198488461609acc)