### PR TITLE
Hotfix: Enforce customer data on Stripe finalize & fix success/admin order displays

### DIFF
--- a/netlify/functions/_shared/finalizeStripeOrder.cjs
+++ b/netlify/functions/_shared/finalizeStripeOrder.cjs
@@ -127,6 +127,29 @@ async function finalizeStripeOrder({ paymentIntentId, orderId, chargeId, walletT
     ? String(customerName).trim().split(/\s+/)[0]
     : null;
 
+  const normalizedEmail = (fallbackEmail || row.email || '').trim().toLowerCase();
+  const looksLikeGuestPlaceholder = normalizedEmail.startsWith('guest-') && normalizedEmail.endsWith('@bannersonthefly.com');
+  const hasRequiredCustomerInfo = Boolean(
+    customerName
+    && normalizedEmail
+    && !looksLikeGuestPlaceholder
+    && shippingStreet
+    && shippingCity
+    && shippingState
+    && shippingZip
+  );
+  if (!hasRequiredCustomerInfo) {
+    console.error(`${tag} refusing finalize for ${row.id}: missing required customer info`, {
+      hasName: !!customerName,
+      hasEmail: !!normalizedEmail && !looksLikeGuestPlaceholder,
+      hasStreet: !!shippingStreet,
+      hasCity: !!shippingCity,
+      hasState: !!shippingState,
+      hasZip: !!shippingZip,
+    });
+    return { ok: false, error: 'MISSING_CUSTOMER_INFO' };
+  }
+
   try {
     await sql`
       UPDATE orders

--- a/netlify/functions/stripe-finalize-order.cjs
+++ b/netlify/functions/stripe-finalize-order.cjs
@@ -195,8 +195,9 @@ exports.handler = async (event) => {
     });
 
     if (!result.ok) {
+      const statusCode = result.error === 'MISSING_CUSTOMER_INFO' ? 409 : 500;
       return {
-        statusCode: 500,
+        statusCode,
         headers,
         body: JSON.stringify(result),
       };

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -47,13 +47,30 @@ const PaymentSuccess: React.FC = () => {
       postalCode?: string;
       country?: string;
     } | null;
+    subtotal_cents?: number;
+    tax_cents?: number;
+    total_cents?: number;
+    applied_discount_cents?: number;
+    applied_discount_label?: string;
+    applied_discount_type?: string;
+    same_day_fee_cents?: number;
+    saturday_fee_cents?: number;
   } | null>(null);
   
   // Get data from navigation state or defaults
   const items = loadedOrder?.items || state?.items || [];
   const total = state?.total || 0;
   const discountCode = state?.discountCode || null;
-  const serverPricing = state?.serverPricing || null; // Server-computed pricing from create-order
+  const serverPricing = loadedOrder
+    ? {
+        applied_discount_type: loadedOrder.applied_discount_type,
+        applied_discount_label: loadedOrder.applied_discount_label,
+        subtotal_cents: loadedOrder.subtotal_cents,
+        tax_cents: loadedOrder.tax_cents,
+        total_cents: loadedOrder.total_cents,
+        applied_discount_cents: loadedOrder.applied_discount_cents,
+      }
+    : (state?.serverPricing || null); // Prefer canonical DB pricing
   const stateShippingAddress = normalizeShippingAddress(state?.shippingAddress || {});
   const loadedShippingAddress = normalizeShippingAddress(loadedOrder?.shippingAddress || {});
   const normalizedShippingAddress = hasShippingAddress(loadedShippingAddress)
@@ -137,7 +154,7 @@ const PaymentSuccess: React.FC = () => {
   }, [orderId]); // Track once when orderId is available
   const calculatePricingBreakdown = () => {
     if (items.length === 0) {
-      return { subtotal: 0, tax: 0, total: 0, discountCents: 0, discountLabel: "" };
+      return { subtotal: 0, tax: 0, total: 0, discountCents: 0, discountLabel: "", shippingCents: 0 };
     }
 
     // FIXED: Use server-computed pricing when available (includes discount calculations)
@@ -155,6 +172,7 @@ const PaymentSuccess: React.FC = () => {
         total: serverPricing.total_cents || 0,
         discountCents: serverPricing.applied_discount_cents || 0,
         discountLabel,
+        shippingCents: 0,
       };
     }
 
@@ -169,6 +187,7 @@ const PaymentSuccess: React.FC = () => {
       total: totalCents,
       discountCents: 0,
       discountLabel: "",
+      shippingCents: 0,
     };
   };
 
@@ -289,6 +308,12 @@ const PaymentSuccess: React.FC = () => {
                     </span>
                   </div>
                 )}
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-700">Shipping</span>
+                  <span className="text-gray-900">
+                    {pricing.shippingCents > 0 ? usd(pricing.shippingCents / 100) : 'FREE'}
+                  </span>
+                </div>
                 <div className="flex justify-between items-center">
                   <span className="text-gray-700">Tax (6%)</span>
                   <span className="text-gray-900">

--- a/src/pages/admin/Orders.tsx
+++ b/src/pages/admin/Orders.tsx
@@ -118,6 +118,13 @@ const getPaymentMethodInfo = (order: Order): PaymentMethodInfo | null => {
   return { label: method.charAt(0).toUpperCase() + method.slice(1), className: 'bg-gray-100 text-gray-700' };
 };
 
+const isHiddenStripeAttempt = (order: Order): boolean => {
+  const method = (order.payment_method || '').toLowerCase();
+  const isStripe = method === 'stripe' || !!order.stripe_payment_intent_id;
+  if (!isStripe) return false;
+  return order.status === 'pending' || order.status === 'failed' || order.status === 'canceled' || order.status === 'cancelled';
+};
+
 const AdminOrders: React.FC = () => {
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
@@ -287,8 +294,9 @@ const AdminOrders: React.FC = () => {
         }
       }
       
+      const visibleOrders = allOrders.filter((order) => !isHiddenStripeAttempt(order));
       setHasMore(allOrders.length === PAGE_SIZE);
-      setOrders(allOrders);
+      setOrders(visibleOrders);
     } catch (error) {
       console.error('Error loading orders:', error);
       toast({


### PR DESCRIPTION
### Motivation
- Stop Stripe flows from creating/marking orders paid when required customer/shipping data is missing, which produced admin rows showing `Not provided` and incorrect emails.
- Ensure the payment success page shows the canonical pricing breakdown (subtotal, discount, shipping, tax, total) that matches checkout/admin/email.
- Hide incomplete/failed Stripe pre-payment attempts from the main admin Orders list so they don't look like real pending orders.
- Preserve existing idempotency and PayPal behavior while making Stripe post-payment flows stricter and clearer.

### Description
- Enforce required customer data in the Stripe finalizer by validating name, a non-placeholder email, and shipping street/city/state/zip before marking an order `paid`, returning `{ error: 'MISSING_CUSTOMER_INFO' }` when data is missing (updated `netlify/functions/_shared/finalizeStripeOrder.cjs`).
- Map the `MISSING_CUSTOMER_INFO` finalizer result to HTTP `409` in the browser finalize endpoint so the client can handle it as a recoverable conflict instead of a generic server error (updated `netlify/functions/stripe-finalize-order.cjs`).
- Make the payment success page prefer canonical DB pricing when available (use `get-order` data for `subtotal/tax/discount/total`) and add an explicit `Shipping` row so the confirmation matches checkout/admin/email formatting (`src/pages/PaymentSuccess.tsx`).
- Hide incomplete Stripe attempts from the main admin Orders list by filtering out Stripe orders in `pending`, `failed`, `canceled`/`cancelled` statuses so abandoned attempts no longer appear as normal pending customer orders (`src/pages/admin/Orders.tsx`).
- Kept existing idempotent behavior (already-paid is a no-op) and made no changes to PayPal flows or the notify/email pipeline.

### Testing
- Ran `npm run build` and the production build completed successfully without fatal errors.
- Committed the changes with `git commit` (local commit created) as part of the hotfix workflow.
- Manual / live tests still required: end-to-end Stripe Card/Apple Pay/Google Pay flows to confirm collection of required customer info and proper client recovery UI for `409 MISSING_CUSTOMER_INFO`; webhook + browser finalize race scenarios to verify single order marking and single set of emails; admin overview counters if you want metrics to exclude hidden Stripe attempts (currently only the displayed Orders list is filtered).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa1a619dc833387c3e78cd4e4183b)