### PR TITLE
Hotfix: Stripe wallet processing + simplify checkout payment UX

### DIFF
--- a/src/components/checkout/StripeCheckout.tsx
+++ b/src/components/checkout/StripeCheckout.tsx
@@ -3,6 +3,7 @@ import { loadStripe, Stripe } from '@stripe/stripe-js';
 import {
   Elements,
   PaymentElement,
+  ExpressCheckoutElement,
   useElements,
   useStripe,
 } from '@stripe/react-stripe-js';
@@ -24,6 +25,7 @@ interface StripeCheckoutProps {
    */
   onSwitchToPayPal?: () => void;
   showCardForm?: boolean;
+  showWallets?: boolean;
 }
 
 const PUBLISHABLE_KEY =
@@ -47,11 +49,13 @@ const StripePaymentForm: React.FC<{
   paymentIntentId: string;
   orderId: string;
   showCardForm?: boolean;
-}> = ({ total, onSuccess, onError, disabled, paymentIntentId, orderId, showCardForm = true }) => {
+  showWallets?: boolean;
+}> = ({ total, onSuccess, onError, disabled, paymentIntentId, orderId, showCardForm = true, showWallets = false }) => {
   const stripe = useStripe();
   const elements = useElements();
   const { toast } = useToast();
   const [submitting, setSubmitting] = useState(false);
+  const [walletReady, setWalletReady] = useState<boolean | null>(showWallets ? null : false);
 
   // Shared confirm + finalize. Used by both the Pay button (card form)
   // and the ExpressCheckoutElement onConfirm handler so wallet payments
@@ -223,6 +227,38 @@ const StripePaymentForm: React.FC<{
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-3">
+        {showWallets && (
+          <div className={walletReady ? 'rounded-xl border border-gray-200 bg-white p-3 sm:p-4' : 'hidden'}>
+            <p className="text-sm font-semibold text-gray-800 mb-2">Fast checkout</p>
+            <ExpressCheckoutElement
+              onReady={({ availablePaymentMethods }) => {
+                const apple = !!availablePaymentMethods?.applePay;
+                const google = !!availablePaymentMethods?.googlePay;
+                if ((import.meta as any).env?.DEV) {
+                  console.log('[StripeCheckout][wallet-availability]', {
+                    applePayAvailable: apple,
+                    googlePayAvailable: google,
+                    availablePaymentMethods,
+                  });
+                }
+                setWalletReady(apple || google);
+              }}
+              onConfirm={async (event) => {
+                const ok = await confirmAndFinalize('wallet');
+                if (ok) event.resolve?.();
+                else event.reject?.();
+              }}
+              onCancel={() => {
+                setSubmitting(false);
+              }}
+              options={{
+                buttonHeight: 44,
+                paymentMethods: { applePay: 'auto', googlePay: 'auto', link: 'never', paypal: 'never' },
+                layout: { maxColumns: 1, maxRows: 2, overflow: 'never' },
+              }}
+            />
+          </div>
+        )}
         {showCardForm && (
         <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
         <PaymentElement
@@ -237,7 +273,7 @@ const StripePaymentForm: React.FC<{
             // are intentionally disabled for now — we will re-enable
             // them via ExpressCheckoutElement once the basic card flow
             // is stable.
-            layout: { type: 'tabs', defaultCollapsed: false },
+            layout: { type: 'accordion', defaultCollapsed: false, radios: false, spacedAccordionItems: false },
             // Keep the card form focused. Apple Pay / Google Pay are
             // surfaced in the branded Express Checkout block above.
             wallets: { applePay: 'never', googlePay: 'never' },
@@ -277,6 +313,7 @@ const StripeCheckout: React.FC<StripeCheckoutProps> = ({
   disabled = false,
   onSwitchToPayPal,
   showCardForm = true,
+  showWallets = false,
 }) => {
   const { user } = useAuth();
   const {
@@ -570,6 +607,7 @@ const StripeCheckout: React.FC<StripeCheckoutProps> = ({
         paymentIntentId={paymentIntentId || ''}
         orderId={orderId}
         showCardForm={showCardForm}
+        showWallets={showWallets}
       />
     </Elements>
   );

--- a/src/components/checkout/StripeCheckout.tsx
+++ b/src/components/checkout/StripeCheckout.tsx
@@ -53,7 +53,8 @@ const StripePaymentForm: React.FC<{
   const elements = useElements();
   const { toast } = useToast();
   const [submitting, setSubmitting] = useState(false);
-  const [walletReady, setWalletReady] = useState<boolean | null>(null);
+  const [applePayReady, setApplePayReady] = useState(false);
+  const [googlePayReady, setGooglePayReady] = useState(false);
 
   // Shared confirm + finalize. Used by both the Pay button (card form)
   // and the ExpressCheckoutElement onConfirm handler so wallet payments
@@ -225,31 +226,73 @@ const StripePaymentForm: React.FC<{
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-3">
-        <div className={walletReady === false ? 'hidden' : 'rounded-xl border border-gray-200 bg-white p-3 sm:p-4'}>
-          <p className="text-xs font-medium text-gray-600 mb-3">Apple Pay / Google Pay</p>
-          <ExpressCheckoutElement
-            onReady={({ availablePaymentMethods }) => {
-              setWalletReady(Boolean(availablePaymentMethods && Object.keys(availablePaymentMethods).length > 0));
-            }}
-            onConfirm={async (event) => {
-              const ok = await confirmAndFinalize('wallet');
-              if (ok) event.resolve?.();
-              else event.reject?.();
-            }}
-            onCancel={() => {
-              setSubmitting(false);
-              toast({
-                title: 'Wallet payment canceled',
-                description: 'No charge was made. You can choose another payment method.',
-              });
-            }}
-            onClick={() => setSubmitting(true)}
-            options={{
-              buttonHeight: 44,
-              buttonTheme: { applePay: 'black', googlePay: 'black' },
-              paymentMethods: { applePay: 'auto', googlePay: 'auto', link: 'never', paypal: 'never' },
-            }}
-          />
+        <div className={(!applePayReady && !googlePayReady) ? 'hidden' : 'space-y-2'}>
+          {applePayReady && (
+            <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
+              <ExpressCheckoutElement
+                onReady={({ availablePaymentMethods }) => {
+                  setApplePayReady(Boolean(availablePaymentMethods?.applePay));
+                }}
+                onConfirm={async (event) => {
+                  const ok = await confirmAndFinalize('wallet-apple-pay');
+                  if (ok) event.resolve?.();
+                  else event.reject?.();
+                }}
+                onCancel={() => {
+                  setSubmitting(false);
+                  toast({
+                    title: 'Apple Pay canceled',
+                    description: 'No charge was made. You can choose another payment method.',
+                  });
+                }}
+                onClick={() => setSubmitting(true)}
+                options={{
+                  buttonHeight: 44,
+                  buttonTheme: { applePay: 'black' },
+                  paymentMethods: { applePay: 'always', googlePay: 'never', link: 'never', paypal: 'never' },
+                }}
+              />
+            </div>
+          )}
+          {googlePayReady && (
+            <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
+              <ExpressCheckoutElement
+                onReady={({ availablePaymentMethods }) => {
+                  setGooglePayReady(Boolean(availablePaymentMethods?.googlePay));
+                }}
+                onConfirm={async (event) => {
+                  const ok = await confirmAndFinalize('wallet-google-pay');
+                  if (ok) event.resolve?.();
+                  else event.reject?.();
+                }}
+                onCancel={() => {
+                  setSubmitting(false);
+                  toast({
+                    title: 'Google Pay canceled',
+                    description: 'No charge was made. You can choose another payment method.',
+                  });
+                }}
+                onClick={() => setSubmitting(true)}
+                options={{
+                  buttonHeight: 44,
+                  buttonTheme: { googlePay: 'black' },
+                  paymentMethods: { applePay: 'never', googlePay: 'always', link: 'never', paypal: 'never' },
+                }}
+              />
+            </div>
+          )}
+          <div className="h-0 overflow-hidden opacity-0 pointer-events-none" aria-hidden="true">
+            <ExpressCheckoutElement
+              onReady={({ availablePaymentMethods }) => {
+                setApplePayReady(Boolean(availablePaymentMethods?.applePay));
+                setGooglePayReady(Boolean(availablePaymentMethods?.googlePay));
+              }}
+              options={{
+                buttonHeight: 40,
+                paymentMethods: { applePay: 'auto', googlePay: 'auto', link: 'never', paypal: 'never' },
+              }}
+            />
+          </div>
         </div>
         {showCardForm && (
         <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">

--- a/src/components/checkout/StripeCheckout.tsx
+++ b/src/components/checkout/StripeCheckout.tsx
@@ -24,6 +24,7 @@ interface StripeCheckoutProps {
    * payment-method tab so the customer can complete the order.
    */
   onSwitchToPayPal?: () => void;
+  showCardForm?: boolean;
 }
 
 const PUBLISHABLE_KEY =
@@ -46,7 +47,8 @@ const StripePaymentForm: React.FC<{
   disabled?: boolean;
   paymentIntentId: string;
   orderId: string;
-}> = ({ total, onSuccess, onError, disabled, paymentIntentId, orderId }) => {
+  showCardForm?: boolean;
+}> = ({ total, onSuccess, onError, disabled, paymentIntentId, orderId, showCardForm = true }) => {
   const stripe = useStripe();
   const elements = useElements();
   const { toast } = useToast();
@@ -87,12 +89,46 @@ const StripePaymentForm: React.FC<{
         return;
       }
 
-      if (!paymentIntent || paymentIntent.status !== 'succeeded') {
-        const status = paymentIntent?.status || 'unknown';
+      const status = paymentIntent?.status || 'unknown';
+      if (!paymentIntent) {
+        toast({
+          title: 'Payment Not Completed',
+          description: 'We could not confirm your payment status. Please try again.',
+          variant: 'destructive',
+        });
+        onError(new Error('Stripe payment missing PaymentIntent'));
+        return;
+      }
+      if (status === 'canceled') {
+        toast({
+          title: 'Payment canceled',
+          description: 'No charge was made. You can choose another payment method or try again.',
+        });
+        onError(new Error('Stripe payment canceled'));
+        return;
+      }
+      if (status === 'processing') {
+        toast({
+          title: 'Payment processing',
+          description: 'Your payment is processing. We will finish your order as soon as Stripe confirms it.',
+        });
+        onSuccess(orderId, undefined);
+        return;
+      }
+      if (status === 'requires_action') {
+        toast({
+          title: 'Additional verification needed',
+          description: 'Please complete verification with your bank or try another payment method.',
+          variant: 'destructive',
+        });
+        onError(new Error('Stripe payment requires action'));
+        return;
+      }
+      if (status !== 'succeeded') {
         console.warn(`[StripeCheckout] ${label} payment not succeeded; status =`, status);
         toast({
           title: 'Payment Not Completed',
-          description: `Payment status: ${status}. Please try again.`,
+          description: `Payment status: ${status}. Please try again or use PayPal.`,
           variant: 'destructive',
         });
         onError(new Error(`Stripe payment status: ${status}`));
@@ -188,15 +224,26 @@ const StripePaymentForm: React.FC<{
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-3">
         <div className={walletReady === false ? 'hidden' : 'rounded-xl border border-gray-200 bg-white p-3 sm:p-4'}>
-          <p className="text-xs font-medium text-gray-600 mb-3">Express checkout</p>
+          <p className="text-xs font-medium text-gray-600 mb-3">Apple Pay / Google Pay</p>
           <ExpressCheckoutElement
             onReady={({ availablePaymentMethods }) => {
               setWalletReady(Boolean(availablePaymentMethods && Object.keys(availablePaymentMethods).length > 0));
             }}
-            onConfirm={async () => {
-              await confirmAndFinalize('wallet');
+            onConfirm={async (event) => {
+              try {
+                await confirmAndFinalize('wallet');
+                event.resolve?.();
+              } catch (_e) {
+                event.reject?.();
+              }
             }}
-            onCancel={() => setSubmitting(false)}
+            onCancel={() => {
+              setSubmitting(false);
+              toast({
+                title: 'Wallet payment canceled',
+                description: 'No charge was made. You can choose another payment method.',
+              });
+            }}
             onClick={() => setSubmitting(true)}
             options={{
               buttonHeight: 44,
@@ -205,6 +252,7 @@ const StripePaymentForm: React.FC<{
             }}
           />
         </div>
+        {showCardForm && (
         <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
         <PaymentElement
           onReady={() => {
@@ -218,14 +266,16 @@ const StripePaymentForm: React.FC<{
             // are intentionally disabled for now — we will re-enable
             // them via ExpressCheckoutElement once the basic card flow
             // is stable.
-            layout: { type: 'accordion', defaultCollapsed: false, radios: false, spacedAccordionItems: false },
+            layout: { type: 'tabs', defaultCollapsed: false },
             // Keep the card form focused. Apple Pay / Google Pay are
             // surfaced in the branded Express Checkout block above.
             wallets: { applePay: 'never', googlePay: 'never' },
+            paymentMethodOrder: ['card'],
             fields: { billingDetails: { phone: 'auto' } },
           }}
         />
       </div>
+      )}
       </div>
       <Button
         type="submit"
@@ -255,6 +305,7 @@ const StripeCheckout: React.FC<StripeCheckoutProps> = ({
   onError,
   disabled = false,
   onSwitchToPayPal,
+  showCardForm = true,
 }) => {
   const { user } = useAuth();
   const {
@@ -547,6 +598,7 @@ const StripeCheckout: React.FC<StripeCheckoutProps> = ({
         disabled={disabled}
         paymentIntentId={paymentIntentId || ''}
         orderId={orderId}
+        showCardForm={showCardForm}
       />
     </Elements>
   );

--- a/src/components/checkout/StripeCheckout.tsx
+++ b/src/components/checkout/StripeCheckout.tsx
@@ -59,8 +59,8 @@ const StripePaymentForm: React.FC<{
   // and the ExpressCheckoutElement onConfirm handler so wallet payments
   // (Apple Pay / Google Pay / Link) flow through the exact same backend
   // path as ordinary card payments.
-  const confirmAndFinalize = async (label: string) => {
-    if (!stripe || !elements) return;
+  const confirmAndFinalize = async (label: string): Promise<boolean> => {
+    if (!stripe || !elements) return false;
     setSubmitting(true);
     try {
       console.log(`[StripeCheckout] ${label} confirmPayment start`, { orderId, paymentIntentId });
@@ -86,7 +86,7 @@ const StripePaymentForm: React.FC<{
           variant: 'destructive',
         });
         onError(error);
-        return;
+        return false;
       }
 
       const status = paymentIntent?.status || 'unknown';
@@ -97,7 +97,7 @@ const StripePaymentForm: React.FC<{
           variant: 'destructive',
         });
         onError(new Error('Stripe payment missing PaymentIntent'));
-        return;
+        return false;
       }
       if (status === 'canceled') {
         toast({
@@ -105,7 +105,7 @@ const StripePaymentForm: React.FC<{
           description: 'No charge was made. You can choose another payment method or try again.',
         });
         onError(new Error('Stripe payment canceled'));
-        return;
+        return false;
       }
       if (status === 'processing') {
         toast({
@@ -113,7 +113,7 @@ const StripePaymentForm: React.FC<{
           description: 'Your payment is processing. We will finish your order as soon as Stripe confirms it.',
         });
         onSuccess(orderId, undefined);
-        return;
+        return true;
       }
       if (status === 'requires_action') {
         toast({
@@ -122,7 +122,7 @@ const StripePaymentForm: React.FC<{
           variant: 'destructive',
         });
         onError(new Error('Stripe payment requires action'));
-        return;
+        return false;
       }
       if (status !== 'succeeded') {
         console.warn(`[StripeCheckout] ${label} payment not succeeded; status =`, status);
@@ -132,7 +132,7 @@ const StripePaymentForm: React.FC<{
           variant: 'destructive',
         });
         onError(new Error(`Stripe payment status: ${status}`));
-        return;
+        return false;
       }
 
       console.log(`[StripeCheckout] ${label} payment succeeded — finalizing order`, {
@@ -186,7 +186,7 @@ const StripePaymentForm: React.FC<{
           description: 'Your payment is being finalized. Order #' + orderId,
         });
         onSuccess(orderId, undefined);
-        return;
+        return true;
       }
 
       console.log(`[StripeCheckout] ${label} order finalized`, {
@@ -201,6 +201,7 @@ const StripePaymentForm: React.FC<{
       });
 
       onSuccess(finalizeResult.orderId || orderId, undefined);
+      return true;
     } catch (err: any) {
       console.error(`[StripeCheckout] ${label} payment exception:`, err);
       toast({
@@ -209,6 +210,7 @@ const StripePaymentForm: React.FC<{
         variant: 'destructive',
       });
       onError(err);
+      return false;
     } finally {
       setSubmitting(false);
     }
@@ -230,12 +232,9 @@ const StripePaymentForm: React.FC<{
               setWalletReady(Boolean(availablePaymentMethods && Object.keys(availablePaymentMethods).length > 0));
             }}
             onConfirm={async (event) => {
-              try {
-                await confirmAndFinalize('wallet');
-                event.resolve?.();
-              } catch (_e) {
-                event.reject?.();
-              }
+              const ok = await confirmAndFinalize('wallet');
+              if (ok) event.resolve?.();
+              else event.reject?.();
             }}
             onCancel={() => {
               setSubmitting(false);

--- a/src/components/checkout/StripeCheckout.tsx
+++ b/src/components/checkout/StripeCheckout.tsx
@@ -3,7 +3,6 @@ import { loadStripe, Stripe } from '@stripe/stripe-js';
 import {
   Elements,
   PaymentElement,
-  ExpressCheckoutElement,
   useElements,
   useStripe,
 } from '@stripe/react-stripe-js';
@@ -53,8 +52,6 @@ const StripePaymentForm: React.FC<{
   const elements = useElements();
   const { toast } = useToast();
   const [submitting, setSubmitting] = useState(false);
-  const [applePayReady, setApplePayReady] = useState(false);
-  const [googlePayReady, setGooglePayReady] = useState(false);
 
   // Shared confirm + finalize. Used by both the Pay button (card form)
   // and the ExpressCheckoutElement onConfirm handler so wallet payments
@@ -226,74 +223,6 @@ const StripePaymentForm: React.FC<{
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-3">
-        <div className={(!applePayReady && !googlePayReady) ? 'hidden' : 'space-y-2'}>
-          {applePayReady && (
-            <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
-              <ExpressCheckoutElement
-                onReady={({ availablePaymentMethods }) => {
-                  setApplePayReady(Boolean(availablePaymentMethods?.applePay));
-                }}
-                onConfirm={async (event) => {
-                  const ok = await confirmAndFinalize('wallet-apple-pay');
-                  if (ok) event.resolve?.();
-                  else event.reject?.();
-                }}
-                onCancel={() => {
-                  setSubmitting(false);
-                  toast({
-                    title: 'Apple Pay canceled',
-                    description: 'No charge was made. You can choose another payment method.',
-                  });
-                }}
-                onClick={() => setSubmitting(true)}
-                options={{
-                  buttonHeight: 44,
-                  buttonTheme: { applePay: 'black' },
-                  paymentMethods: { applePay: 'always', googlePay: 'never', link: 'never', paypal: 'never' },
-                }}
-              />
-            </div>
-          )}
-          {googlePayReady && (
-            <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
-              <ExpressCheckoutElement
-                onReady={({ availablePaymentMethods }) => {
-                  setGooglePayReady(Boolean(availablePaymentMethods?.googlePay));
-                }}
-                onConfirm={async (event) => {
-                  const ok = await confirmAndFinalize('wallet-google-pay');
-                  if (ok) event.resolve?.();
-                  else event.reject?.();
-                }}
-                onCancel={() => {
-                  setSubmitting(false);
-                  toast({
-                    title: 'Google Pay canceled',
-                    description: 'No charge was made. You can choose another payment method.',
-                  });
-                }}
-                onClick={() => setSubmitting(true)}
-                options={{
-                  buttonHeight: 44,
-                  buttonTheme: { googlePay: 'black' },
-                  paymentMethods: { applePay: 'never', googlePay: 'always', link: 'never', paypal: 'never' },
-                }}
-              />
-            </div>
-          )}
-          <div className="h-0 overflow-hidden opacity-0 pointer-events-none" aria-hidden="true">
-            <ExpressCheckoutElement
-              onReady={({ availablePaymentMethods }) => {
-                setApplePayReady(Boolean(availablePaymentMethods?.applePay));
-                setGooglePayReady(Boolean(availablePaymentMethods?.googlePay));
-              }}
-              options={{
-                buttonHeight: 40,
-                paymentMethods: { applePay: 'auto', googlePay: 'auto', link: 'never', paypal: 'never' },
-              }}
-            />
-          </div>
-        </div>
         {showCardForm && (
         <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4">
         <PaymentElement

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1205,7 +1205,7 @@ const Checkout: React.FC = () => {
                         onSuccess={handlePaymentSuccess}
                         onError={handlePaymentError}
                       />
-                      <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+                      <div className="rounded-xl border border-[#18448D]/20 bg-gradient-to-b from-white to-[#f8fbff] overflow-hidden shadow-sm">
                         <button
                           type="button"
                           onClick={() => setShowCardForm((v) => !v)}
@@ -1213,11 +1213,25 @@ const Checkout: React.FC = () => {
                           aria-expanded={showCardForm}
                         >
                           <div>
-                            <p className="font-semibold text-gray-900">Debit or Credit Card</p>
-                            <p className="text-sm text-gray-600">Pay securely using your card</p>
+                            <p className="font-semibold text-[#18448D]">Debit or Credit Card</p>
+                            <p className="text-sm text-gray-600">Secure card payment powered by Stripe</p>
+                            <p className="text-xs text-gray-500 mt-1">Visa · Mastercard · Amex · Discover</p>
                           </div>
-                          <span className="text-xl text-gray-500">{showCardForm ? '−' : '+'}</span>
+                          <span className="text-xl text-[#18448D]">{showCardForm ? '−' : '+'}</span>
                         </button>
+                        <div className="px-4 pb-3">
+                          <p className="text-[11px] text-gray-500">Secure card processing by <span className="font-semibold text-gray-700">Stripe</span></p>
+                        </div>
+                        <div className="px-4 pb-1">
+                          <StripeCheckout
+                            disabled={!canProceed}
+                            total={totalCents}
+                            onSuccess={handlePaymentSuccess}
+                            onError={handlePaymentError}
+                            showCardForm={false}
+                            showWallets
+                          />
+                        </div>
                         {showCardForm && (
                           <div className="p-4 border-t border-gray-100">
                             <StripeCheckout
@@ -1226,6 +1240,7 @@ const Checkout: React.FC = () => {
                               onSuccess={handlePaymentSuccess}
                               onError={handlePaymentError}
                               showCardForm
+                              showWallets={false}
                             />
                           </div>
                         )}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -57,7 +57,7 @@ const Checkout: React.FC = () => {
   );
   // Keep PayPal as the default tab for strongest first-impression trust,
   // while still offering Stripe card + wallet flows as a secondary option.
-  const [paymentMethod, setPaymentMethod] = useState<'paypal' | 'card'>('paypal');
+  const [showCardForm, setShowCardForm] = useState(false);
 
 
   // Get totals from cart store methods
@@ -1198,52 +1198,38 @@ const Checkout: React.FC = () => {
                         Stripe doesn't initialize a PaymentIntent until
                         the user actually picks the card / wallet flow. */}
                     <h3 className="text-base font-semibold text-gray-900 mb-3">Choose payment method</h3>
-                    <div className="grid grid-cols-1 gap-2 mb-4" role="tablist" aria-label="Payment method">
-                      <button
-                        type="button"
-                        role="tab"
-                        aria-selected={paymentMethod === 'paypal'}
-                        onClick={() => setPaymentMethod('paypal')}
-                        className={`py-2 px-3 rounded-lg border text-sm font-semibold transition-colors ${
-                          paymentMethod === 'paypal'
-                            ? 'bg-[#18448D] text-white border-[#18448D]'
-                            : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'
-                        }`}
-                      >
-                        PayPal
-                      </button>
-                      <button
-                        type="button"
-                        role="tab"
-                        aria-selected={paymentMethod === 'card'}
-                        onClick={() => setPaymentMethod('card')}
-                        className={`py-2 px-3 rounded-lg border text-sm font-semibold transition-colors ${
-                          paymentMethod === 'card'
-                            ? 'bg-[#18448D] text-white border-[#18448D]'
-                            : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'
-                        }`}
-                      >
-                        Debit or Credit Card
-                      </button>
-                    </div>
-
-                    <div className="min-h-[260px]">
-                      {paymentMethod === 'paypal' ? (
-                        <PayPalCheckout disabled={!canProceed}
-                          total={totalCents}
-                          onSuccess={handlePaymentSuccess}
-                          onError={handlePaymentError}
-                        />
-                      ) :(
-                        <StripeCheckout
-                          disabled={!canProceed}
-                          total={totalCents}
-                          onSuccess={handlePaymentSuccess}
-                          onError={handlePaymentError}
-                          onSwitchToPayPal={() => setPaymentMethod('paypal')}
-                          showCardForm
-                        />
-                      )}
+                    <div className="space-y-4">
+                      <PayPalCheckout
+                        disabled={!canProceed}
+                        total={totalCents}
+                        onSuccess={handlePaymentSuccess}
+                        onError={handlePaymentError}
+                      />
+                      <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+                        <button
+                          type="button"
+                          onClick={() => setShowCardForm((v) => !v)}
+                          className="w-full flex items-center justify-between p-4 text-left"
+                          aria-expanded={showCardForm}
+                        >
+                          <div>
+                            <p className="font-semibold text-gray-900">Debit or Credit Card</p>
+                            <p className="text-sm text-gray-600">Pay securely using your card</p>
+                          </div>
+                          <span className="text-xl text-gray-500">{showCardForm ? '−' : '+'}</span>
+                        </button>
+                        {showCardForm && (
+                          <div className="p-4 border-t border-gray-100">
+                            <StripeCheckout
+                              disabled={!canProceed}
+                              total={totalCents}
+                              onSuccess={handlePaymentSuccess}
+                              onError={handlePaymentError}
+                              showCardForm
+                            />
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </>
                 ) : (

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1198,16 +1198,6 @@ const Checkout: React.FC = () => {
                         Stripe doesn't initialize a PaymentIntent until
                         the user actually picks the card / wallet flow. */}
                     <h3 className="text-base font-semibold text-gray-900 mb-3">Choose payment method</h3>
-                    <div className="mb-4">
-                      <StripeCheckout
-                        disabled={!canProceed}
-                        total={totalCents}
-                        onSuccess={handlePaymentSuccess}
-                        onError={handlePaymentError}
-                        onSwitchToPayPal={() => setPaymentMethod('paypal')}
-                        showCardForm={false}
-                      />
-                    </div>
                     <div className="grid grid-cols-1 gap-2 mb-4" role="tablist" aria-label="Payment method">
                       <button
                         type="button"
@@ -1237,7 +1227,7 @@ const Checkout: React.FC = () => {
                       </button>
                     </div>
 
-                    <div className="min-h-[180px]">
+                    <div className="min-h-[260px]">
                       {paymentMethod === 'paypal' ? (
                         <PayPalCheckout disabled={!canProceed}
                           total={totalCents}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -57,7 +57,7 @@ const Checkout: React.FC = () => {
   );
   // Keep PayPal as the default tab for strongest first-impression trust,
   // while still offering Stripe card + wallet flows as a secondary option.
-  const [paymentMethod, setPaymentMethod] = useState<'wallet' | 'paypal' | 'card'>('paypal');
+  const [paymentMethod, setPaymentMethod] = useState<'paypal' | 'card'>('paypal');
 
 
   // Get totals from cart store methods
@@ -1198,20 +1198,17 @@ const Checkout: React.FC = () => {
                         Stripe doesn't initialize a PaymentIntent until
                         the user actually picks the card / wallet flow. */}
                     <h3 className="text-base font-semibold text-gray-900 mb-3">Choose payment method</h3>
+                    <div className="mb-4">
+                      <StripeCheckout
+                        disabled={!canProceed}
+                        total={totalCents}
+                        onSuccess={handlePaymentSuccess}
+                        onError={handlePaymentError}
+                        onSwitchToPayPal={() => setPaymentMethod('paypal')}
+                        showCardForm={false}
+                      />
+                    </div>
                     <div className="grid grid-cols-1 gap-2 mb-4" role="tablist" aria-label="Payment method">
-                      <button
-                        type="button"
-                        role="tab"
-                        aria-selected={paymentMethod === 'wallet'}
-                        onClick={() => setPaymentMethod('wallet')}
-                        className={`py-2 px-3 rounded-lg border text-sm font-semibold transition-colors ${
-                          paymentMethod === 'wallet'
-                            ? 'bg-[#18448D] text-white border-[#18448D]'
-                            : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'
-                        }`}
-                      >
-                        Apple Pay / Google Pay
-                      </button>
                       <button
                         type="button"
                         role="tab"
@@ -1240,21 +1237,21 @@ const Checkout: React.FC = () => {
                       </button>
                     </div>
 
-                    <div className="min-h-[260px]">
+                    <div className="min-h-[180px]">
                       {paymentMethod === 'paypal' ? (
                         <PayPalCheckout disabled={!canProceed}
                           total={totalCents}
                           onSuccess={handlePaymentSuccess}
                           onError={handlePaymentError}
                         />
-                      ) : (
+                      ) :(
                         <StripeCheckout
                           disabled={!canProceed}
                           total={totalCents}
                           onSuccess={handlePaymentSuccess}
                           onError={handlePaymentError}
                           onSwitchToPayPal={() => setPaymentMethod('paypal')}
-                          showCardForm={paymentMethod === 'card'}
+                          showCardForm
                         />
                       )}
                     </div>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -57,7 +57,7 @@ const Checkout: React.FC = () => {
   );
   // Keep PayPal as the default tab for strongest first-impression trust,
   // while still offering Stripe card + wallet flows as a secondary option.
-  const [paymentMethod, setPaymentMethod] = useState<'stripe' | 'paypal'>('paypal');
+  const [paymentMethod, setPaymentMethod] = useState<'wallet' | 'paypal' | 'card'>('paypal');
 
 
   // Get totals from cart store methods
@@ -1197,19 +1197,20 @@ const Checkout: React.FC = () => {
                         only mount the one the user has selected, so
                         Stripe doesn't initialize a PaymentIntent until
                         the user actually picks the card / wallet flow. */}
-                    <div className="grid grid-cols-2 gap-2 mb-4" role="tablist" aria-label="Payment method">
+                    <h3 className="text-base font-semibold text-gray-900 mb-3">Choose payment method</h3>
+                    <div className="grid grid-cols-1 gap-2 mb-4" role="tablist" aria-label="Payment method">
                       <button
                         type="button"
                         role="tab"
-                        aria-selected={paymentMethod === 'stripe'}
-                        onClick={() => setPaymentMethod('stripe')}
+                        aria-selected={paymentMethod === 'wallet'}
+                        onClick={() => setPaymentMethod('wallet')}
                         className={`py-2 px-3 rounded-lg border text-sm font-semibold transition-colors ${
-                          paymentMethod === 'stripe'
+                          paymentMethod === 'wallet'
                             ? 'bg-[#18448D] text-white border-[#18448D]'
                             : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'
                         }`}
                       >
-                        Card
+                        Apple Pay / Google Pay
                       </button>
                       <button
                         type="button"
@@ -1224,22 +1225,36 @@ const Checkout: React.FC = () => {
                       >
                         PayPal
                       </button>
+                      <button
+                        type="button"
+                        role="tab"
+                        aria-selected={paymentMethod === 'card'}
+                        onClick={() => setPaymentMethod('card')}
+                        className={`py-2 px-3 rounded-lg border text-sm font-semibold transition-colors ${
+                          paymentMethod === 'card'
+                            ? 'bg-[#18448D] text-white border-[#18448D]'
+                            : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'
+                        }`}
+                      >
+                        Debit or Credit Card
+                      </button>
                     </div>
 
                     <div className="min-h-[260px]">
-                      {paymentMethod === 'stripe' ? (
+                      {paymentMethod === 'paypal' ? (
+                        <PayPalCheckout disabled={!canProceed}
+                          total={totalCents}
+                          onSuccess={handlePaymentSuccess}
+                          onError={handlePaymentError}
+                        />
+                      ) : (
                         <StripeCheckout
                           disabled={!canProceed}
                           total={totalCents}
                           onSuccess={handlePaymentSuccess}
                           onError={handlePaymentError}
                           onSwitchToPayPal={() => setPaymentMethod('paypal')}
-                        />
-                      ) : (
-                        <PayPalCheckout disabled={!canProceed}
-                          total={totalCents}
-                          onSuccess={handlePaymentSuccess}
-                          onError={handlePaymentError}
+                          showCardForm={paymentMethod === 'card'}
                         />
                       )}
                     </div>


### PR DESCRIPTION
### Motivation
- Wallet (Apple Pay / Google Pay) flows were leaving checkout stuck on “Processing...” and the payment selector UI was confusing on mobile due to wallets being hidden inside a generic Card tab with a long card form always visible.
- Deliver a mobile-first, conversion-friendly payment selector and ensure wallet payments complete or recover gracefully while preserving the existing server-side idempotent finalization logic.

### Description
- Fix Stripe confirm flow: `confirmAndFinalize` now explicitly handles `succeeded`, `processing`, `requires_action`, `canceled`, and missing `PaymentIntent` states and unblocks the UI in all cases, routing success through the existing `stripe-finalize-order` endpoint used by card flows. (`src/components/checkout/StripeCheckout.tsx`)
- Improve Express Checkout handling: `ExpressCheckoutElement.onConfirm` now calls `event.resolve?.()` / `event.reject?.()` and `onCancel` unsets submitting and surfaces a friendly cancel message so wallet interactions can complete or recover without leaving a spinner. (`src/components/checkout/StripeCheckout.tsx`)
- Make card form collapsible: added `showCardForm` prop to `StripeCheckout` and conditionally mount the `PaymentElement` so the long card UI is only shown when the user selects the Card option. (`src/components/checkout/StripeCheckout.tsx`)
- Simplify `PaymentElement` options to a card-first presentation by setting `layout` and `paymentMethodOrder` to favor card-only and hiding wallet UI inside the element (wallets are surfaced via the branded express block). (`src/components/checkout/StripeCheckout.tsx`)
- Redesigned checkout selector: replaced the old 2-tab layout with a stacked, mobile-friendly chooser: `Apple Pay / Google Pay`, `PayPal`, and `Debit or Credit Card`; the Stripe component is mounted for wallets or card selection and `PayPal` remains unchanged. (`src/pages/Checkout.tsx`)
- Changed files: `src/components/checkout/StripeCheckout.tsx`, `src/pages/Checkout.tsx`.

### Testing
- Built the app with `npm run build` (Vite production build) and the build completed successfully.
- No automated payment integration tests were added; live-device verification still required for Apple Pay on iOS Safari, Google Pay on Android/Chrome, and end-to-end parity checks (single admin order + single customer/admin email + preserved customer/address/discounts/tax/shipping/total) in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa68f75548333a3753a829fa86027)