### PR TITLE
Hotfix: Temporarily disable Stripe checkout and hide Stripe pending guest orders in admin

### DIFF
--- a/netlify/functions/get-orders.cjs
+++ b/netlify/functions/get-orders.cjs
@@ -321,6 +321,18 @@ exports.handler = async (event, context) => {
                 ) as items
            FROM orders o
            LEFT JOIN order_items oi ON o.id = oi.order_id
+           WHERE NOT (
+             COALESCE(o.payment_method, '') = 'stripe'
+             AND COALESCE(o.status, '') = 'pending'
+             AND o.paypal_order_id IS NULL
+             AND o.paypal_capture_id IS NULL
+             AND o.stripe_charge_id IS NULL
+             AND (
+               o.email IS NULL
+               OR NULLIF(TRIM(o.email), '') IS NULL
+               OR LOWER(TRIM(COALESCE(o.customer_name, ''))) IN ('guest', 'guest customer')
+             )
+           )
            GROUP BY o.id
            ORDER BY o.created_at DESC
            LIMIT $1 OFFSET $2`,

--- a/netlify/functions/stripe-create-payment-intent.cjs
+++ b/netlify/functions/stripe-create-payment-intent.cjs
@@ -27,6 +27,10 @@ const {
 } = require('./_shared/checkoutTotals.cjs');
 
 const sql = neon(process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL);
+// Emergency kill switch: keep Stripe code in place, but block new Stripe
+// checkout starts so no pre-payment placeholder orders can be created while
+// Stripe flow is under investigation/stabilization.
+const STRIPE_CHECKOUT_TEMP_DISABLED = true;
 
 // Guard: only treat a value as a "real" authenticated user id if it is a
 // proper non-zero UUID. Placeholder values like the all-zero UUID, the
@@ -129,6 +133,19 @@ exports.handler = async (event) => {
       statusCode: 405,
       headers,
       body: JSON.stringify({ ok: false, error: 'METHOD_NOT_ALLOWED', cid }),
+    };
+  }
+
+  if (STRIPE_CHECKOUT_TEMP_DISABLED) {
+    return {
+      statusCode: 503,
+      headers,
+      body: JSON.stringify({
+        ok: false,
+        error: 'STRIPE_TEMP_DISABLED',
+        message: 'Stripe checkout is temporarily unavailable. Please use PayPal.',
+        cid,
+      }),
     };
   }
 
@@ -438,4 +455,3 @@ exports.handler = async (event) => {
     };
   }
 };
-

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -49,7 +49,7 @@ const Checkout: React.FC = () => {
   // in checkout. When false, the Stripe tab is hidden and PayPal is the only
   // available payment method. Stripe code/components are preserved so this can
   // be re-enabled later by simply switching ENABLE_STRIPE to true.
-  const ENABLE_STRIPE = true;
+  const ENABLE_STRIPE = false;
   // Selected payment provider tab. Stripe (cards + Apple/Google Pay) is
   // shown first when configured; PayPal remains as an alternative.
   const stripeAvailable = ENABLE_STRIPE && Boolean(


### PR DESCRIPTION
### Motivation
- Stop the live admin Orders page from filling with fake/guest `pending` rows generated by Stripe checkout setup attempts. 
- Prevent any new Stripe pre-payment placeholder orders from being created while the Stripe flow is investigated. 
- Restore checkout trust by exposing PayPal as the only live payment option until Stripe is stable.

### Description
- Frontend: turn off Stripe UI by setting `ENABLE_STRIPE = false` in `src/pages/Checkout.tsx` so cards/Apple Pay/Google Pay are hidden and PayPal is the default. 
- Backend: add an emergency kill switch `STRIPE_CHECKOUT_TEMP_DISABLED = true` in `netlify/functions/stripe-create-payment-intent.cjs` that returns `503 STRIPE_TEMP_DISABLED` to block new Stripe checkout starts and stop creation of pre-payment pending orders. 
- Admin filtering: update the admin fetch in `netlify/functions/get-orders.cjs` to exclude likely Stripe-generated fake rows by filtering `payment_method='stripe'` + `status='pending'` + no capture/charge ids + missing/guest-like email/name, so existing polluted records are hidden from the main Orders list (non-destructive). 
- Preservation: no Stripe code was removed; paid/real Stripe and PayPal orders, shipped/in-production orders, and all non-order business logic (pricing, tracking, thumbnails, emails) remain unchanged and will still surface in admin.

### Testing
- Ran `npm run build` and the production bundle completed successfully (build succeeded); non-blocking warnings produced (Browserslist/CSS minify warnings) but did not fail the build. 
- Verified the three changed files: `src/pages/Checkout.tsx`, `netlify/functions/stripe-create-payment-intent.cjs`, and `netlify/functions/get-orders.cjs` were updated and included in the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab5c4ad348333a9561cf72f04b507)