### PR TITLE
Hotfix: Use canonical order totals (include Same-Day Hit Service) on /orders/:id

### DIFF
--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -74,6 +74,8 @@ interface Order {
   applied_discount_cents?: number;
   applied_discount_label?: string;
   applied_discount_type?: string;
+  same_day_fee_cents?: number;
+  saturday_fee_cents?: number;
   shipping_name?: string | null;
   shipping_street?: string | null;
   shipping_street2?: string | null;
@@ -444,40 +446,38 @@ const OrderDetail: React.FC = () => {
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <h2 className="text-lg font-semibold text-gray-900 mb-4">Order Summary</h2>
             <div className="space-y-2">
-              {(() => {
-                // Recalculate tax/total from line items minus discount
-                // Same approach as notify-order.cjs
-                const rawSubtotal = order.items.reduce((sum, item) => sum + item.line_total_cents, 0);
-                const discountCents = order.applied_discount_cents || 0;
-                const afterDiscount = rawSubtotal - discountCents;
-                const calculatedTax = Math.round(afterDiscount * 0.06);
-                const calculatedTotal = afterDiscount + calculatedTax;
-                
-                return (
-                    <>
-                    <div className="flex justify-between text-gray-600">
-                      <span>Subtotal</span>
-                      <span>{formatCurrency(rawSubtotal)}</span>
-                    </div>
-                    {discountCents > 0 && (
-                      <div className="flex justify-between text-green-600 font-medium">
-                        <span>{order.applied_discount_label || "Discount"}</span>
-                        <span>-{formatCurrency(discountCents)}</span>
-                      </div>
-                    )}
-                    <div className="flex justify-between text-gray-600">
-                      <span>Tax</span>
-                      <span>{formatCurrency(calculatedTax)}</span>
-                    </div>
-                    <div className="border-t border-gray-200 pt-2 mt-2">
-                      <div className="flex justify-between text-lg font-semibold text-gray-900">
-                        <span>Total</span>
-                        <span>{formatCurrency(calculatedTotal)}</span>
-                      </div>
-                    </div>
-                    </>
-                );
-              })()}
+              <div className="flex justify-between text-gray-600">
+                <span>Subtotal</span>
+                <span>{formatCurrency(order.subtotal_cents || 0)}</span>
+              </div>
+              {(order.applied_discount_cents || 0) > 0 && (
+                <div className="flex justify-between text-green-600 font-medium">
+                  <span>{order.applied_discount_label || "Discount"}</span>
+                  <span>-{formatCurrency(order.applied_discount_cents || 0)}</span>
+                </div>
+              )}
+              {(order.same_day_fee_cents || 0) > 0 && (
+                <div className="flex justify-between text-gray-600">
+                  <span>Same-Day Hit Service</span>
+                  <span>{formatCurrency(order.same_day_fee_cents || 0)}</span>
+                </div>
+              )}
+              {(order.saturday_fee_cents || 0) > 0 && (
+                <div className="flex justify-between text-gray-600">
+                  <span>Saturday Delivery</span>
+                  <span>{formatCurrency(order.saturday_fee_cents || 0)}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-gray-600">
+                <span>Tax</span>
+                <span>{formatCurrency(order.tax_cents || 0)}</span>
+              </div>
+              <div className="border-t border-gray-200 pt-2 mt-2">
+                <div className="flex justify-between text-lg font-semibold text-gray-900">
+                  <span>Total</span>
+                  <span>{formatCurrency(getDisplayOrderTotalCents(order as any))}</span>
+                </div>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation
- The `/orders/:id` “View Full Order” page was recomputing totals from line items and tax and therefore omitted the Same-Day Hit Service fee shown elsewhere. 
- Because admin/customer email “View Full Order” links point to this route, the discrepancy caused emails to show incorrect totals. 
- The goal is to ensure every order display uses the canonical persisted pricing fields and the shared total helper so Same-Day fees are shown everywhere and normal orders are unaffected.

### Description
- Replaced manual subtotal+tax recalculation in `src/pages/OrderDetail.tsx` with canonical fields and the shared helper by rendering `order.subtotal_cents`, `order.tax_cents`, `order.same_day_fee_cents`, `order.saturday_fee_cents`, and `getDisplayOrderTotalCents(order)`. 
- Added `same_day_fee_cents` and `saturday_fee_cents` to the local `Order` interface in `src/pages/OrderDetail.tsx`. 
- Removed the old block that recomputed `rawSubtotal`, `calculatedTax`, and `calculatedTotal` from `order.items` to avoid subtotal+tax-only displays and prevent double-adds. 
- Change set is limited to a single file: `src/pages/OrderDetail.tsx`.

### Testing
- Ran `npm run build` and the production build completed successfully (non-blocking warnings present); build step passed. 
- Verified the modified page now displays subtotal, discount, Same-Day Hit Service line and fee, tax, and total via `getDisplayOrderTotalCents`. 
- Files changed by this PR: `src/pages/OrderDetail.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabe65fb8c833396dffa9af88ea15d)