### PR TITLE
Fix customer name/email truncation across public and admin order views

### DIFF
--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -256,26 +256,26 @@ const OrderDetail: React.FC = () => {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 text-sm">
-              <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex items-center space-x-2">
+              <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex flex-wrap items-start gap-x-2 gap-y-1">
                 <Package className="h-4 w-4 text-gray-400" />
                 <span className="text-gray-600">Customer:</span>
-                <span className="font-medium truncate">{customerName}</span>
+                <span className="font-medium break-words" title={customerName}>{customerName}</span>
               </div>
-              <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex items-center space-x-2">
+              <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex flex-wrap items-start gap-x-2 gap-y-1">
                 <Mail className="h-4 w-4 text-gray-400" />
                 <span className="text-gray-600">Email:</span>
-                <span className="font-medium truncate">{order.email}</span>
+                <span className="font-medium break-all" title={order.email}>{order.email}</span>
               </div>
-              <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex items-center space-x-2">
+              <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex flex-wrap items-start gap-x-2 gap-y-1">
                 <CreditCard className="h-4 w-4 text-gray-400" />
                 <span className="text-gray-600">Total:</span>
                 <span className="font-medium">{formatCurrency(getDisplayOrderTotalCents(order as any))}</span>
               </div>
               {order.tracking_number && (
-                <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex items-center space-x-2">
+                <div className="min-w-0 rounded-md border border-gray-200 bg-gray-50 p-3 flex flex-wrap items-start gap-x-2 gap-y-1">
                   <Truck className="h-4 w-4 text-gray-400" />
                   <span className="text-gray-600">Tracking:</span>
-                  <span className="font-medium truncate">{order.tracking_number}</span>
+                  <span className="font-medium break-all" title={order.tracking_number}>{order.tracking_number}</span>
                 </div>
               )}
             </div>

--- a/src/pages/admin/Orders.tsx
+++ b/src/pages/admin/Orders.tsx
@@ -1430,10 +1430,10 @@ const AdminOrderRow: React.FC<AdminOrderRowProps> = ({
             <div className="text-xs text-gray-500">
               {new Date(order.created_at).toLocaleDateString()}
             </div>
-            <div className="text-sm font-medium text-gray-900 truncate">
+            <div className="text-sm font-medium text-gray-900 break-words" title={order.customer_name || order.shipping_name || "Guest Customer"}>
               {order.customer_name || order.shipping_name || 'Guest Customer'}
             </div>
-            <div className="text-xs text-gray-600 truncate">
+            <div className="text-xs text-gray-600 break-all" title={order.email || (order.user_id ? `${order.user_id.slice(0, 8)}...` : "No email")}>
               {order.email || (order.user_id ? `${order.user_id.slice(0, 8)}...` : 'No email')}
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Customer name and email were being truncated with ellipses in the order header cards, making order identification and support harder. 
- The goal is to show full customer name/email where reasonable and wrap to a second line on small screens instead of hiding important info. 
- Apply the change consistently for public `/orders/:id`, admin order detail preview, and shared order pages used by email links while preserving layout responsiveness.

### Description
- Replaced `truncate`/single-line truncation styles with wrapping-friendly utilities and container wrapping in `src/pages/OrderDetail.tsx` by adding `flex flex-wrap` to card containers and using `break-words` / `break-all` on customer name, email, and tracking fields. 
- Mirrored the change in `src/pages/admin/Orders.tsx` by switching the customer name/email cells from `truncate` to `break-words` / `break-all` and adding `title` attributes so the full values are available on hover. 
- Added `title` tooltip fallbacks for customer name, email, and tracking number to preserve access to full values when layouts are constrained, without changing desktop/tablet mobile styling otherwise.

### Testing
- Ran `npm run build` and the production build completed successfully (build emitted CSS minify warnings but produced the `dist/` output). 
- No unit/test-suite runs were performed as part of this change; validation was limited to a successful production build and visual/layout checks during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac1b94f6c8333b0257a93ad7ede8d)