### PR TITLE
Add admin-protected emergency endpoint to resend order emails

### DIFF
--- a/netlify/functions/notify-order.cjs
+++ b/netlify/functions/notify-order.cjs
@@ -672,8 +672,8 @@ exports.handler = async (event) => {
   }
 
   try {
-    const { orderId } = JSON.parse(event.body || '{}');
-    console.log('[notify-order] handler start', { orderId });
+    const { orderId, forceResendBoth = false } = JSON.parse(event.body || '{}');
+    console.log('[notify-order] handler start', { orderId, forceResendBoth });
     
     if (!orderId || typeof orderId !== 'string') {
       return {
@@ -717,7 +717,7 @@ exports.handler = async (event) => {
     });
 
     // Idempotency Check: If already sent, return success without sending
-    if (order.confirmation_email_status === 'sent' || order.confirmation_emailed_at) {
+    if (!forceResendBoth && (order.confirmation_email_status === 'sent' || order.confirmation_emailed_at)) {
       console.log(`Order ${orderId} confirmation email already sent, returning idempotent response`);
       return {
         statusCode: 200,
@@ -879,6 +879,8 @@ exports.handler = async (event) => {
 
     // Send confirmation email
     const emailResult = await sendEmail('order.confirmation', emailPayload);
+    let adminEmailResult = null;
+    const adminEmail = process.env.ADMIN_EMAIL || 'info@bannersonthefly.com';
     console.log('[notify-order] confirmation send result', { orderId, ok: emailResult.ok, error: emailResult.error });
     
     // Log email attempt
@@ -903,8 +905,6 @@ exports.handler = async (event) => {
       console.log(`Order confirmation email sent successfully for order ${orderId}, email ID: ${emailResult.id}`);
 
       // Send admin notification email to info@bannersonthefly.com
-      const adminEmail = process.env.ADMIN_EMAIL || 'info@bannersonthefly.com';
-
       try {
         // Add delay to prevent rate limiting (Resend allows 2 requests per second)
         await new Promise(resolve => setTimeout(resolve, 1000));
@@ -919,7 +919,7 @@ exports.handler = async (event) => {
           invoiceUrl: emailPayload.invoiceUrl
         };
 
-        const adminEmailResult = await sendEmail('order.admin_notification', adminEmailPayload);
+        adminEmailResult = await sendEmail('order.admin_notification', adminEmailPayload);
         console.log('[notify-order] admin send result', {
           orderId,
           adminEmail,
@@ -966,7 +966,20 @@ exports.handler = async (event) => {
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify({ ok: true, id: emailResult.id })
+        body: JSON.stringify({
+          ok: true,
+          orderId,
+          customerEmailSent: !!emailResult.ok,
+          adminEmailSent: !!adminEmailResult?.ok,
+          resendMessageIds: {
+            customer: emailResult.id || null,
+            admin: adminEmailResult?.id || null,
+          },
+          errors: [
+            ...(!emailResult.ok ? [`Customer confirmation failed: ${emailResult.error || 'unknown error'}`] : []),
+            ...(adminEmailResult && !adminEmailResult.ok ? [`Admin notification failed: ${adminEmailResult.error || 'unknown error'}`] : [])
+          ]
+        })
       };
     } else {
       console.error(`Order confirmation email failed for order ${orderId}:`, emailResult);

--- a/netlify/functions/resend-order-emails.cjs
+++ b/netlify/functions/resend-order-emails.cjs
@@ -1,0 +1,82 @@
+const { neon } = require('@neondatabase/serverless');
+const { handler: notifyOrderHandler } = require('./notify-order.cjs');
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-admin-secret',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+function isAuthorized(event) {
+  const secret = process.env.RESEND_ORDER_EMAIL_SECRET;
+  if (!secret) return false;
+
+  const authHeader = event.headers?.authorization || event.headers?.Authorization || '';
+  const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+  const headerSecret = event.headers?.['x-admin-secret'] || event.headers?.['X-Admin-Secret'] || '';
+  return bearer === secret || headerSecret === secret;
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.httpMethod !== 'POST') return { statusCode: 405, headers, body: JSON.stringify({ ok: false, error: 'Method not allowed' }) };
+
+  if (!isAuthorized(event)) {
+    return { statusCode: 401, headers, body: JSON.stringify({ ok: false, error: 'Unauthorized' }) };
+  }
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    let { orderId, latest = false } = body;
+
+    const dbUrl = process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL;
+    if (!dbUrl) return { statusCode: 500, headers, body: JSON.stringify({ ok: false, error: 'Database not configured' }) };
+
+    const db = neon(dbUrl);
+
+    if (!orderId) {
+      if (!latest) {
+        return { statusCode: 400, headers, body: JSON.stringify({ ok: false, error: 'Provide orderId or latest=true' }) };
+      }
+
+      const latestPaid = await db`
+        SELECT id
+        FROM orders
+        WHERE status = 'paid'
+        ORDER BY created_at DESC
+        LIMIT 1
+      `;
+
+      if (latestPaid.length === 0) {
+        return { statusCode: 404, headers, body: JSON.stringify({ ok: false, error: 'No paid orders found' }) };
+      }
+
+      orderId = latestPaid[0].id;
+    }
+
+    const notifyResponse = await notifyOrderHandler({
+      httpMethod: 'POST',
+      headers: event.headers || {},
+      body: JSON.stringify({ orderId, forceResendBoth: true }),
+    });
+
+    const parsed = JSON.parse(notifyResponse.body || '{}');
+
+    return {
+      statusCode: notifyResponse.statusCode || 200,
+      headers,
+      body: JSON.stringify({
+        ok: !!parsed.ok,
+        orderId,
+        customerEmailSent: !!parsed.customerEmailSent,
+        adminEmailSent: !!parsed.adminEmailSent,
+        resendMessageIds: parsed.resendMessageIds || { customer: null, admin: null },
+        errors: parsed.errors || (parsed.error ? [parsed.error] : []),
+      }),
+    };
+  } catch (error) {
+    console.error('[resend-order-emails] failed:', error);
+    return { statusCode: 500, headers, body: JSON.stringify({ ok: false, error: 'Internal server error', details: error.message }) };
+  }
+};


### PR DESCRIPTION
### Motivation
- Provide an emergency one-time way to resend both transactional emails for an existing order (customer order confirmation and admin new-order notification) using the existing email templates and Resend logic.
- Allow operators to target either a specific order (`orderId`) or the most recent paid order (`latest=true`) when a previously-sent email was missed.
- Ensure the flow uses the same logging and `email_events` tracking already used by the system and that the endpoint is protected for admin use via a temporary secret.

### Description
- Added a new Netlify function `/.netlify/functions/resend-order-emails` that accepts `orderId` or `latest=true`, resolves the latest paid order when requested, enforces admin authorization with `RESEND_ORDER_EMAIL_SECRET` via `Authorization: Bearer <secret>` or `x-admin-secret`, invokes the existing notify-order pipeline, and returns clear JSON (`orderId`, `customerEmailSent`, `adminEmailSent`, `resendMessageIds`, `errors`).
- Reused the existing `notify-order` implementation by calling its handler with a `forceResendBoth: true` flag so both the customer confirmation and admin notification are sent through the same templates and Resend logic.
- Updated `notify-order.cjs` to accept the optional `forceResendBoth` flag, bypass the idempotent short-circuit when set, capture the admin send result into `adminEmailResult`, and expand the success response to include per-email booleans, Resend message IDs, and any per-email errors.
- All existing behavior that logs to `email_events` and updates `orders` email status columns remains intact and is used by the resend path for consistent tracking.

### Testing
- Performed syntax checks with `node -c netlify/functions/resend-order-emails.cjs` and `node -c netlify/functions/notify-order.cjs`, both of which succeeded.
- Verified the new function loads and the modified `notify-order` handler can be required and executed programmatically (local validation of handler invocation completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb686bd9008333a4321c6c253ed1cf)