### PR TITLE
Fix AI debug UI: capture full fetch envelope and add Netlify debugPing responses

### DIFF
--- a/netlify/functions/ai-generate-banner-test.cjs
+++ b/netlify/functions/ai-generate-banner-test.cjs
@@ -8,6 +8,21 @@ exports.handler = async (event) => {
   };
 
   if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.queryStringParameters?.debugPing === 'true') {
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        success: true,
+        message: 'Function reached',
+        timestamp: new Date().toISOString(),
+        env: {
+          hasOpenAIKey: Boolean(process.env.OPENAI_API_KEY),
+          hasCloudinary: Boolean(process.env.CLOUDINARY_CLOUD_NAME && process.env.CLOUDINARY_API_KEY && process.env.CLOUDINARY_API_SECRET)
+        }
+      })
+    };
+  }
   if (event.httpMethod !== 'POST') return { statusCode: 405, headers, body: JSON.stringify({ success: false, status: 405, code: 'method_not_allowed', type: 'request_validation', message: 'Method not allowed' }) };
 
   try {

--- a/netlify/functions/generate-ai-designs.cjs
+++ b/netlify/functions/generate-ai-designs.cjs
@@ -106,6 +106,21 @@ exports.handler = async (event) => {
   };
 
   if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.queryStringParameters?.debugPing === 'true') {
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        success: true,
+        message: 'Function reached',
+        timestamp: new Date().toISOString(),
+        env: {
+          hasOpenAIKey: Boolean(process.env.OPENAI_API_KEY),
+          hasCloudinary: Boolean(process.env.CLOUDINARY_CLOUD_NAME && process.env.CLOUDINARY_API_KEY && process.env.CLOUDINARY_API_SECRET)
+        }
+      })
+    };
+  }
 
   const isProduction = process.env.CONTEXT === 'production' || process.env.NODE_ENV === 'production';
   const debug = { success: false, stepFailed: null, durationMs: 0, model: 'gpt-image-1', openaiStatus: null, cloudinaryStatus: null, imageDetected: false, inspirationIncluded: false, fallbackAttempted: false, fallbackSucceeded: false, error: null, errorMessage: null, openaiError: null, cloudinaryError: null };

--- a/src/components/design/CreateWithAIModal.tsx
+++ b/src/components/design/CreateWithAIModal.tsx
@@ -16,6 +16,7 @@ type DesignResult = { imageUrl: string; prompt: string; originalPrompt: string; 
 type ApiError = { category?: string | null; message?: string | null; status?: number | null; code?: string | null; type?: string | null; details?: string | null };
 type GenerationDebug = { success?: boolean; stepFailed?: string | null; durationMs?: number; model?: string; openaiStatus?: string | null; cloudinaryStatus?: string | null; imageDetected?: boolean; inspirationIncluded?: boolean; fallbackAttempted?: boolean; fallbackSucceeded?: boolean; error?: string | ApiError | null; openaiError?: ApiError | null };
 type GenerationResponse = { success?: boolean; stepFailed?: string | null; durationMs?: number; model?: string; imageDetected?: boolean; inspirationIncluded?: boolean; fallbackAttempted?: boolean; fallbackSucceeded?: boolean; openaiStatus?: string | null; cloudinaryStatus?: string | null; error?: ApiError | string | null; image?: { url?: string }; images?: Array<{ url?: string }>; prompt?: string; debug?: GenerationDebug | null };
+type FetchDebugRecord = { httpStatus: number | null; ok: boolean | null; rawText: string; parsedJson: unknown; fetchError: string | null };
 const CreateWithAIModal: React.FC<CreateWithAIModalProps> = (props) => ENABLE_AI ? <CreateWithAIModalImpl {...props} /> : null;
 
 const toBase64FromUrl = async (url: string) => {
@@ -39,12 +40,30 @@ const CreateWithAIModalImpl: React.FC<CreateWithAIModalProps> = ({ open, onOpenC
   const [rawGenerateResponse, setRawGenerateResponse] = useState<string>('');
   const [rawTestResponse, setRawTestResponse] = useState<string>('');
   const requirementsMet = useMemo(() => Number(widthIn) > 0 && Number(heightIn) > 0 && !!material, [widthIn, heightIn, material]);
+  const runDebugFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<{ debugRecord: FetchDebugRecord; response: Response | null }> => {
+    try {
+      const response = await fetch(input, init);
+      const rawText = await response.text();
+      let parsedJson: unknown = null;
+      try { parsedJson = rawText ? JSON.parse(rawText) : null; } catch { parsedJson = null; }
+      return {
+        response,
+        debugRecord: { httpStatus: response.status, ok: response.ok, rawText, parsedJson, fetchError: null }
+      };
+    } catch (error) {
+      return {
+        response: null,
+        debugRecord: { httpStatus: null, ok: null, rawText: '', parsedJson: null, fetchError: error instanceof Error ? error.message : String(error) }
+      };
+    }
+  };
 
   const generate = async (basePrompt: string, regenerate = false) => {
     const payload = { prompt: basePrompt, regenerate, productType, width: widthIn, height: heightIn, material, quantity, size: { wIn: widthIn, hIn: heightIn }, inspirationImage: inspirationDataUrl, brandMatchStrength, styleChips: CHIPS.filter((c)=>basePrompt.includes(c)) };
-    const res = await fetch('/.netlify/functions/generate-ai-designs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
-    const body: GenerationResponse = await res.json().catch(() => ({} as GenerationResponse));
-    setRawGenerateResponse(JSON.stringify(body, null, 2));
+    const { response: res, debugRecord } = await runDebugFetch('/.netlify/functions/generate-ai-designs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    setRawGenerateResponse(JSON.stringify(debugRecord, null, 2));
+    const body: GenerationResponse = (debugRecord.parsedJson && typeof debugRecord.parsedJson === 'object' ? debugRecord.parsedJson : {}) as GenerationResponse;
+    if (!res) throw new Error(debugRecord.fetchError || 'Network error while calling generate-ai-designs');
     setDebugInfo(body?.debug || body || null);
     if (!res.ok) {
       const errObj = typeof body?.error === 'object' ? body.error : null;
@@ -85,13 +104,14 @@ const CreateWithAIModalImpl: React.FC<CreateWithAIModalProps> = ({ open, onOpenC
     setIsGenerating(true);
     setError(null);
     try {
-      const res = await fetch('/.netlify/functions/ai-generate-banner-test', {
+      const { response: res, debugRecord } = await runDebugFetch('/.netlify/functions/ai-generate-banner-test', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt: prompt.trim() })
       });
-      const body = await res.json().catch(() => ({}));
-      setRawTestResponse(JSON.stringify(body, null, 2));
+      setRawTestResponse(JSON.stringify(debugRecord, null, 2));
+      const body = (debugRecord.parsedJson && typeof debugRecord.parsedJson === 'object' ? debugRecord.parsedJson : {}) as any;
+      if (!res) throw new Error(debugRecord.fetchError || 'Network error while calling ai-generate-banner-test');
       if (!res.ok) throw new Error(JSON.stringify(body));
       const testImage = body?.image?.url;
       if (testImage) setDesign((prev) => ({ imageUrl: testImage, prompt: body?.prompt || prompt, originalPrompt: prompt, revision: (prev?.revision || 0) + 1 }));


### PR DESCRIPTION
### Motivation
- The Raw response panel was showing only `{}` because the frontend only stored parsed JSON and lost transport/raw data or swallow fetch errors. 
- Provide robust visibility into HTTP status, raw text, parse outcome, and fetch errors so the debug UI can distinguish parse failures, network errors, and empty backend payloads. 
- Add a quick `debugPing=true` path in the Netlify functions so the handlers can be sanity-checked directly in a browser or via simple GET without running the full generation flow.

### Description
- Add a `FetchDebugRecord` type and new `runDebugFetch` helper in `src/components/design/CreateWithAIModal.tsx` that performs `fetch()`, reads `response.text()`, attempts `JSON.parse()`, and captures `{ httpStatus, ok, rawText, parsedJson, fetchError }`.
- Replace direct `res.json()` usages for both Generate Design and Run AI Test flows to use `runDebugFetch`, store the full debug envelope in `rawGenerateResponse` / `rawTestResponse`, and use the parsed JSON only as one field of the envelope.
- Update the Raw response panels to display the complete debug object (so the panel will show HTTP status, raw response text, parsed JSON, and fetch error), ensuring `{}` only appears if the actual parsed JSON is `{}`.
- Add an early-return `debugPing=true` branch at the top of both Netlify functions (`netlify/functions/ai-generate-banner-test.cjs` and `netlify/functions/generate-ai-designs.cjs`) which returns a hardcoded JSON with `success`, `message`, `timestamp`, and `env` flags indicating presence of `OPENAI_API_KEY` and Cloudinary creds.

### Testing
- Invoked both function handlers programmatically with an event containing `queryStringParameters.debugPing = 'true'` and confirmed both returned HTTP 200 and the expected JSON payload with `success`, `message`, `timestamp`, and `env` flags (succeeded).
- Verified locally that `CreateWithAIModal` now calls `runDebugFetch` and that the UI state variables `rawGenerateResponse` / `rawTestResponse` are set to the full debug envelope (static code path and runtime invocation validated in the local environment; update confirmed).
- Note: direct browser checks of deployed Netlify routes were not performed from this environment, so manual browser verification of `/.netlify/functions/ai-generate-banner-test?debugPing=true` and `/.netlify/functions/generate-ai-designs?debugPing=true` is recommended after deploy to validate routing and CORS in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb2e6fffc833381258888799696f6)