### PR TITLE
Add OpenAI smoke-test function and temporarily wire Create With AI to baseline generation

### DIFF
--- a/netlify/functions/ai-smoke-test.cjs
+++ b/netlify/functions/ai-smoke-test.cjs
@@ -1,0 +1,81 @@
+const OpenAI = require('openai');
+
+const DEFAULT_PROMPT = 'Create one flat print-ready vinyl banner design for a grand opening sale. No mockups, no grommets, no wall scene.';
+const DEFAULT_SIZE = '1536x1024';
+const MODEL = 'gpt-image-1';
+
+exports.handler = async (event) => {
+  const hasOpenAIKey = Boolean(process.env.OPENAI_API_KEY);
+
+  if (!hasOpenAIKey) {
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        success: false,
+        hasOpenAIKey,
+        model: MODEL,
+        imageReturned: false,
+        rawOpenAIError: 'Missing OPENAI_API_KEY'
+      })
+    };
+  }
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  try {
+    let body = {};
+    if (event.httpMethod === 'POST' && event.body) {
+      try { body = JSON.parse(event.body); } catch (_) { body = {}; }
+    }
+
+    const prompt = typeof body.prompt === 'string' && body.prompt.trim() ? body.prompt.trim() : DEFAULT_PROMPT;
+    const size = typeof body.size === 'string' && body.size.trim() ? body.size.trim() : DEFAULT_SIZE;
+
+    const result = await openai.images.generate({
+      model: MODEL,
+      prompt,
+      size,
+      n: 1
+    });
+
+    const image = result?.data?.[0] || {};
+    const imageUrl = image.url || null;
+    const base64 = image.b64_json || null;
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        success: true,
+        hasOpenAIKey,
+        model: MODEL,
+        imageReturned: Boolean(imageUrl || base64),
+        imageUrl,
+        base64Length: base64 ? base64.length : 0,
+        imageBase64: base64,
+        prompt,
+        size
+      })
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        success: false,
+        hasOpenAIKey,
+        model: MODEL,
+        imageReturned: false,
+        rawOpenAIError: {
+          message: error?.message || 'Unknown OpenAI error',
+          name: error?.name || null,
+          status: error?.status || null,
+          code: error?.code || null,
+          type: error?.type || null,
+          param: error?.param || null
+        }
+      })
+    };
+  }
+};

--- a/src/components/design/CreateWithAIModal.tsx
+++ b/src/components/design/CreateWithAIModal.tsx
@@ -60,10 +60,11 @@ const CreateWithAIModalImpl: React.FC<CreateWithAIModalProps> = ({ open, onOpenC
 
   const generate = async (basePrompt: string, regenerate = false) => {
     const payload = { prompt: basePrompt, regenerate, productType, width: widthIn, height: heightIn, material, quantity, size: { wIn: widthIn, hIn: heightIn }, inspirationImage: inspirationDataUrl, brandMatchStrength, styleChips: CHIPS.filter((c)=>basePrompt.includes(c)) };
-    const { response: res, debugRecord } = await runDebugFetch('/.netlify/functions/generate-ai-designs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    const targetSize = Number(widthIn) >= Number(heightIn) ? '1536x1024' : '1024x1536';
+    const { response: res, debugRecord } = await runDebugFetch('/.netlify/functions/ai-smoke-test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt: basePrompt, size: targetSize }) });
     setRawGenerateResponse(JSON.stringify(debugRecord, null, 2));
-    const body: GenerationResponse = (debugRecord.parsedJson && typeof debugRecord.parsedJson === 'object' ? debugRecord.parsedJson : {}) as GenerationResponse;
-    if (!res) throw new Error(debugRecord.fetchError || 'Network error while calling generate-ai-designs');
+    const body: any = (debugRecord.parsedJson && typeof debugRecord.parsedJson === 'object' ? debugRecord.parsedJson : {}) as any;
+    if (!res) throw new Error(debugRecord.fetchError || 'Network error while calling ai-smoke-test');
     setDebugInfo(body?.debug || body || null);
     if (!res.ok) {
       const errObj = typeof body?.error === 'object' ? body.error : null;
@@ -81,9 +82,11 @@ const CreateWithAIModalImpl: React.FC<CreateWithAIModalProps> = ({ open, onOpenC
       ].filter(Boolean).join('\n');
       throw new Error(detail || JSON.stringify(body));
     }
-    const image = body?.image || body?.images?.[0];
-    if (!image?.url) throw new Error(JSON.stringify(body));
-    return { imageUrl: image.url, prompt: body?.prompt || basePrompt, originalPrompt: basePrompt, revision: (design?.revision || 0) + 1 };
+    const smokeImageUrl = body?.imageUrl || null;
+    const smokeImageBase64 = body?.imageBase64 || null;
+    if (!smokeImageUrl && !smokeImageBase64) throw new Error(JSON.stringify(body));
+    const imageUrl = smokeImageUrl || `data:image/png;base64,${smokeImageBase64}`;
+    return { imageUrl, prompt: body?.prompt || basePrompt, originalPrompt: basePrompt, revision: (design?.revision || 0) + 1 };
   };
 
   const handleGenerate = async (regenerate = false) => {


### PR DESCRIPTION
### Motivation
- Isolate OpenAI image generation failures by verifying a minimal end-to-end path that uses only `OPENAI_API_KEY` and the OpenAI Images API before reintroducing Cloudinary, auth, inspiration upload, or other pipeline pieces.
- Give the frontend a deterministic baseline so users see real OpenAI errors (or a real image) instead of opaque `{}` responses while debugging generation.

### Description
- Added a Netlify function `netlify/functions/ai-smoke-test.cjs` that calls `openai.images.generate` with `model: 'gpt-image-1'`, `n: 1`, and accepts an optional `prompt` and `size`; the function returns structured diagnostics including `success`, `hasOpenAIKey`, `model`, `imageReturned`, `imageUrl`, `base64Length`, `imageBase64` and `rawOpenAIError` on failure.
- Modified `src/components/design/CreateWithAIModal.tsx` to temporarily POST to `/.netlify/functions/ai-smoke-test` (choosing a target size of `1536x1024` or `1024x1536` from product dimensions) instead of the full `generate-ai-designs` pipeline, and to accept either a returned `imageUrl` or a base64 `imageBase64` fallback for rendering.
- Kept existing debug capture (`rawGenerateResponse`, `debugInfo`) so frontend shows full backend response payloads to aid troubleshooting.

### Testing
- Ran a production build with `npm run -s build`, which completed successfully (build exit 0).
- Verified the local dev app compiles and the modified `CreateWithAIModal` builds into the distribution so the smoke-test path is available during manual testing; no automated unit tests were added or altered for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccd3894f083338cef7ca92c97422e)