### PR TITLE
Fix political landing page social metadata and canonical URL

### DIFF
--- a/src/pages/PoliticalSigns.tsx
+++ b/src/pages/PoliticalSigns.tsx
@@ -437,27 +437,28 @@ const PoliticalSigns: React.FC = () => {
   return (
     <Layout>
       <Helmet>
-        <title>Political Campaign Signs & Banners – Designed For You | Banners On The Fly</title>
+        <title>Political Campaign Signs & Banners | Banners On The Fly</title>
         <meta
           name="description"
-          content="Upload your own design or let our designers create one. Printed in 24 hours with free next-day air shipping."
+          content="Fast political campaign signs, banners, and yard signs with free next-day air shipping. Perfect for elections, rallies, events, and local campaigns."
         />
-        <meta property="og:title" content="Political Campaign Signs & Banners – Designed For You" />
+        <link rel="canonical" href="https://bannersonthefly.com/political-signs" />
+        <meta property="og:title" content="Political Campaign Signs & Banners | Banners On The Fly" />
         <meta
           property="og:description"
-          content="Upload your own design or let our designers create one. Printed in 24 hours with free next-day air shipping."
+          content="Fast political campaign signs, banners, and yard signs with free next-day air shipping. Perfect for elections, rallies, events, and local campaigns."
         />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://bannersonthefly.com/campaign-signs" />
+        <meta property="og:url" content="https://bannersonthefly.com/political-signs" />
         <meta
           property="og:image"
           content="https://res.cloudinary.com/dtrxl120u/image/upload/v1778177853/political_banners_cdgdgp.png"
         />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Political Campaign Signs & Banners – Designed For You" />
+        <meta name="twitter:title" content="Political Campaign Signs & Banners | Banners On The Fly" />
         <meta
           name="twitter:description"
-          content="Upload your own design or let our designers create one. Printed in 24 hours with free next-day air shipping."
+          content="Fast political campaign signs, banners, and yard signs with free next-day air shipping. Perfect for elections, rallies, events, and local campaigns."
         />
         <meta
           name="twitter:image"


### PR DESCRIPTION
### Motivation
- Ensure the `/political-signs` route exposes page-specific Open Graph and Twitter/X metadata (title, description, image, url, canonical) so social link previews show political campaign imagery and copy instead of the generic banner preview.
- Keep metadata changes scoped to the political landing page only and avoid impacting graduation, homepage, or other landing pages.

### Description
- Updated the `<Helmet>` block in `src/pages/PoliticalSigns.tsx` to set a unique `title` and `description` for the political landing page.
- Added a route-specific `<link rel="canonical">` pointing to `https://bannersonthefly.com/political-signs` and corrected `og:url` to the same canonical URL.
- Replaced generic share copy with political-specific `og:title`, `og:description`, `twitter:title`, and `twitter:description`, and ensured `twitter:card` is `summary_large_image` while keeping the political hero image as `og:image`/`twitter:image`.
- Scoped the change to `src/pages/PoliticalSigns.tsx` so other pages (e.g., graduation and homepage) retain their existing metadata.

### Testing
- Confirmed the updated tags are present using `rg -n "canonical|og:title|og:description|og:image|og:url|twitter:title|twitter:description|twitter:image|twitter:card" src/pages/PoliticalSigns.tsx` and found the new values.
- Inspected the modified file lines with `nl -ba src/pages/PoliticalSigns.tsx | sed -n '436,470p'` to verify the `title`, `meta`, and `link rel="canonical"` entries are rendered in the page source.
- Ran a repository-wide search for affected metadata to ensure only the political page was changed and no graduation/homepage metadata were altered; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdf532ad88333ae5ac9dd9e313560)