### PR TITLE
Add /political-signs Open Graph and Twitter image metadata

### DIFF
--- a/netlify/edge-functions/social-meta-injector.ts
+++ b/netlify/edge-functions/social-meta-injector.ts
@@ -2,6 +2,13 @@ import type { Context } from "https://edge.netlify.com";
 
 // Static page metadata
 const staticPages: Record<string, { title: string; description: string; image: string; url: string; type: string }> = {
+  "political-signs": {
+    title: "Political Campaign Signs & Banners | Banners On The Fly",
+    description: "Fast political campaign signs, banners, and yard signs with free next-day air shipping.",
+    image: "https://res.cloudinary.com/dtrxl120u/image/upload/v1778180324/Screenshot_2026-05-07_at_2.58.40_PM_h8ozp5.png?v=2",
+    url: "https://bannersonthefly.com/political-signs",
+    type: "website"
+  },
   "graduation-signs": {
     title: "Custom Graduation Signs – Designed For You",
     description: "Upload your own design or let our designers create one. Printed in 24 hours with free next-day air shipping.",


### PR DESCRIPTION
### Motivation
- Ensure the `/political-signs` landing page uses the exact requested social image when shared so platforms display the correct campaign artwork.
- Keep metadata route-specific so homepage, graduation page, and other landing pages remain unchanged.
- Add a cache-busting parameter to help overwrite aggressive OG caching on platforms that cache images.

### Description
- Added a static route entry for `political-signs` to `netlify/edge-functions/social-meta-injector.ts` that sets `title`, `description`, `image`, `url`, and `type` for that page.
- The `image` value is set exactly to `https://res.cloudinary.com/dtrxl120u/image/upload/v1778180324/Screenshot_2026-05-07_at_2.58.40_PM_h8ozp5.png?v=2` (cache-busting `?v=2`).
- The metadata injected for this route uses `og:title = Political Campaign Signs & Banners | Banners On The Fly`, `og:description = Fast political campaign signs, banners, and yard signs with free next-day air shipping.`, and `twitter:card = summary_large_image` while emitting both `og:image` and `twitter:image` from the same route-specific `page.image` value.
- Injection remains scoped to exact path matching (`url.pathname === '/<key>'`) so other pages (homepage, graduation page, blog, etc.) are unaffected.

### Testing
- Searched and inspected the modified edge function and confirmed the new route entry is present by running `nl -ba netlify/edge-functions/social-meta-injector.ts | sed -n '1,70p'` which showed the `political-signs` block (success).
- Verified references to the new key and meta templates with `rg -n "political-signs|twitter:card|og:title|og:description|og:image|twitter:image" netlify/edge-functions/social-meta-injector.ts` which returned the expected lines (success).
- Ran repository checks and commit commands used during the change (`git status --short` and the commit step) which completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce11098488333ba82fcde1220ac23)