### PR TITLE
Remove secondary hero CTA on PoliticalSigns page

### DIFF
--- a/src/pages/PoliticalSigns.tsx
+++ b/src/pages/PoliticalSigns.tsx
@@ -522,19 +522,6 @@ const PoliticalSigns: React.FC = () => {
               >
                 <Upload className="h-5 w-5" /> Start Your Order Today
               </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setFlow('designer');
-                  setTimeout(
-                    () => document.getElementById('flow-section')?.scrollIntoView({ behavior: 'smooth' }),
-                    50
-                  );
-                }}
-                className="inline-flex items-center gap-2 rounded-lg bg-white/10 hover:bg-white/20 border border-white/30 text-white font-bold px-6 py-3.5 text-base shadow-lg transition backdrop-blur"
-              >
-                <Sparkles className="h-5 w-5" /> Shop Yard Signs
-              </button>
             </div>
             <p className="mt-4 text-xs text-white/70 max-w-sm">
               Need help with design? Upload artwork or let our designers create it for you.


### PR DESCRIPTION
### Motivation
- Remove the secondary “Shop Yard Signs” CTA from the PoliticalSigns hero so the hero shows only the primary `Start Your Order Today` action while preserving layout and responsiveness.

### Description
- Deleted the secondary CTA markup in `src/pages/PoliticalSigns.tsx` (removed the `Shop Yard Signs` button) and left the hero CTA wrapper (`flex flex-wrap gap-3`) intact to maintain spacing and responsive alignment.

### Testing
- Ran `npm run -s lint` which reported many unrelated, pre-existing lint errors and therefore failed, and no additional automated tests were added for this targeted markup change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce852f8708333a01648270a912e6e)