### PR TITLE
Speed up ai-generate-banner-test: use minimal fixed OpenAI image to isolate Netlify timeout

### DIFF
--- a/netlify/functions/ai-generate-banner-test.cjs
+++ b/netlify/functions/ai-generate-banner-test.cjs
@@ -30,9 +30,9 @@ exports.handler = async (event) => {
       return { statusCode: 500, headers, body: JSON.stringify({ success: false, stepFailed: 'openai_request', status: 500, code: 'missing_openai_key', type: 'config_error', message: 'OPENAI_API_KEY missing' }) };
     }
 
-    const body = JSON.parse(event.body || '{}');
-    const prompt = (body.prompt || 'Professional flat print-ready banner, bold readable text, no mockup, no hardware.').trim();
-    const size = body.size || '1536x1024';
+    JSON.parse(event.body || '{}'); // Keep parse for request validation/log symmetry; request fields are ignored on purpose for speed tests.
+    const prompt = 'solid blue rectangle';
+    const size = '1024x1024'; // Smallest size supported by gpt-image-1
 
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const response = await openai.images.generate({ model: 'gpt-image-1', prompt, size, n: 1 });


### PR DESCRIPTION
### Motivation
- The `ai-generate-banner-test` endpoint was still hitting Netlify `504 Inactivity Timeout`, so a fastest-possible test is needed to determine whether synchronous Netlify functions can complete OpenAI image generation at all. 
- Provide a deterministic, minimal image generation request that removes variable prompt/size/DB/Cloudinary factors so the test isolates platform latency.

### Description
- Rewrote `netlify/functions/ai-generate-banner-test.cjs` to ignore user-supplied generation inputs and instead call OpenAI with a tiny fixed prompt of `solid blue rectangle`.
- Force the smallest image size used for this endpoint to `1024x1024` to minimize generation time and bandwidth.
- Keep `JSON.parse(event.body || '{}')` for request-shape symmetry and preserve the original response/error JSON shape so existing UI/debugging code can continue to parse the result.

### Testing
- Ran a syntax check with `node --check netlify/functions/ai-generate-banner-test.cjs`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcebda19cc8333a924c1f7c4ca25c1)