### PR TITLE
Improve yard sign upload default quantity UX

### DIFF
--- a/src/components/design/YardSignConfigurator.tsx
+++ b/src/components/design/YardSignConfigurator.tsx
@@ -411,8 +411,8 @@ const YardSignConfigurator: React.FC<YardSignConfiguratorProps> = ({
       const isPdf = file.type === 'application/pdf';
       const thumbnailUrl = isPdf ? getPdfThumbnailUrl(data.secureUrl) : data.secureUrl;
       const presetFirstDesignQuantity = Math.max(
-        1,
-        Math.min(YARD_SIGN_MAX_QUANTITY, initialDesignQuantity || 1),
+        YARD_SIGN_MIN_QUANTITY,
+        Math.min(YARD_SIGN_MAX_QUANTITY, initialDesignQuantity || YARD_SIGN_MIN_QUANTITY),
       );
       const newDesign: YardSignDesign = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
@@ -504,8 +504,8 @@ const YardSignConfigurator: React.FC<YardSignConfiguratorProps> = ({
         <p className="text-xs text-gray-500 mb-2">
           Upload up to {YARD_SIGN_MAX_DESIGNS} designs. Each will be printed at 24&quot; × 18&quot;. Assign a quantity to each design.
         </p>
-        <p className="text-xs text-orange-600 font-medium mb-3">
-          Total order must be in increments of {YARD_SIGN_INCREMENT} signs (10, 20, 30, etc.).
+        <p className="text-xs text-gray-500 font-medium mb-3">
+          Minimum order is {YARD_SIGN_MIN_QUANTITY} signs. Total must be in increments of {YARD_SIGN_INCREMENT}.
         </p>
 
         {/* Design rows */}


### PR DESCRIPTION
### Motivation
- Prevent immediate red validation error after the first yard sign upload by defaulting the first design quantity to the valid minimum so the upload feels complete and valid.

### Description
- Change first-upload quantity logic so the preset first-design quantity uses `YARD_SIGN_MIN_QUANTITY` (instead of `1`) and is clamped by `YARD_SIGN_MAX_QUANTITY` via `initialDesignQuantity` fallback.
- Replace the aggressive warning copy with neutral helper text: “Minimum order is 10 signs. Total must be in increments of 10.” to avoid error styling on initial state.
- No validation rules changed; existing minimum/increment rules and multi-design distribution logic remain intact.

### Testing
- Ran the linter with `npm run -s lint`, which reported pre-existing repository-wide lint failures unrelated to this change and did not indicate any new lint errors caused by this patch (lint run: failed due to unrelated issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe586501d48333bb1dab55ea140f34)