### PR TITLE
Reduce builder friction, clarify CTAs, and make card-via-PayPal messaging explicit (no Stripe changes)

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -65,7 +65,7 @@ const HeroSection: React.FC = () => {
                 onClick={handleUploadOrCreate}
                 className="group relative px-10 py-4 sm:px-11 sm:py-4 bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-red-500 text-white text-lg font-bold rounded-lg transition-all duration-300 min-w-[240px] shadow-xl shadow-orange-900/30 hover:shadow-orange-500/45 hover:shadow-2xl hover:-translate-y-0.5 overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
               >
-                <span className="relative z-10">Upload Your Design →</span>
+                <span className="relative z-10">Upload Design & Continue</span>
                 <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/25 to-transparent opacity-0 group-hover:opacity-100 group-hover:animate-[btn-shine_0.8s_ease-in-out]" />
               </button>
             </div>
@@ -77,7 +77,7 @@ const HeroSection: React.FC = () => {
               </div>
               <div className="flex items-center gap-2">
                 <Lock className="w-4 h-4 text-slate-200" />
-                <span>Secure checkout</span>
+                <span>Secure checkout · No PayPal account required</span>
               </div>
               <div className="flex items-center gap-2">
                 <CheckCircle className="w-4 h-4 text-green-400" />

--- a/src/components/checkout/PayPalCheckout.tsx
+++ b/src/components/checkout/PayPalCheckout.tsx
@@ -649,6 +649,8 @@ const PayPalCheckout: React.FC<PayPalCheckoutProps> = ({ total, onSuccess, onErr
       )}
 
       <PayPalScriptProvider options={initialOptions}>
+
+      <p className="mb-3 text-xs text-gray-600">Pay securely by card or PayPal. No PayPal account required.</p>
         <div className="relative z-10">
           {cardFirstLayout ? (
             <div className="space-y-2.5">

--- a/src/lib/builderSteps.ts
+++ b/src/lib/builderSteps.ts
@@ -252,7 +252,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!isOptionsComplete(state)) {
     return {
       step: 'options',
-      label: 'Choose Options',
+      label: 'More options',
       scrollTargetId: STEP_ANCHORS.options,
       disabled: false,
       loading: false,
@@ -263,7 +263,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!state.hasUpload) {
     return {
       step: 'upload',
-      label: 'Upload Artwork',
+      label: 'Upload Design & Continue',
       scrollTargetId: STEP_ANCHORS.upload,
       disabled: false,
       loading: false,

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1229,13 +1229,13 @@ const Checkout: React.FC = () => {
                         >
                           <div>
                             <p className="font-semibold text-[#18448D]">Debit or Credit Card</p>
-                            <p className="text-sm text-gray-600">Secure card payment powered by Stripe</p>
+                            <p className="text-sm text-gray-600">Secure card payment</p>
                             <p className="text-xs text-gray-500 mt-1">Visa · Mastercard · Amex · Discover</p>
                           </div>
                           <span className="text-xl text-[#18448D]">{showCardForm ? '−' : '+'}</span>
                         </button>
                         <div className="px-4 pb-3">
-                          <p className="text-[11px] text-gray-500">Secure card processing by <span className="font-semibold text-gray-700">Stripe</span></p>
+                          <p className="text-[11px] text-gray-500">Secure card processing</p>
                         </div>
                         <div className="px-4 pb-1">
                           <StripeCheckout
@@ -1266,7 +1266,7 @@ const Checkout: React.FC = () => {
                   <div className="space-y-3">
                     <div className="space-y-2 rounded-lg border border-[#E7D9C7] bg-[#FCF7F0] p-3 shadow-sm">
                       <p className="text-xs text-gray-600">
-                        Checkout securely with a card — no PayPal account required.
+                        Pay securely by card or PayPal. No PayPal account required.
                       </p>
                       <div className="flex justify-center">
                         <img
@@ -1301,8 +1301,8 @@ const Checkout: React.FC = () => {
                       </span>
                     ))}
                   </div>
-                  <p className="mt-2 text-xs text-gray-600">Every order reviewed by a real production team · Custom printed to order · Secure encrypted checkout · Nationwide fulfillment.</p>
-                  <p className="text-xs text-gray-600">Fast turnaround trusted by businesses, events, and campaigns.</p>
+                  <p className="mt-2 text-xs text-gray-600">Secure checkout · No PayPal account required · Upload almost any file type · We check your file before production.</p>
+                  <p className="text-xs text-gray-600">Printed within 24 hours · Free next-day air shipping.</p>
                 </div>
               </div>
 

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -308,7 +308,7 @@ const Design: React.FC = () => {
     // Keep the latest mirror in sync immediately so a rapid second
     // switch can't re-stash the just-restored snapshot.
     latestDesignRef.current = { ...restored };
-    setQuantity(1);
+    setQuantity(newType === 'yard_sign' ? 10 : 1);
     setPromoCode('');
     setPromoApplied(false);
     // Switching product tabs is a fresh start — clear confirmation flags so
@@ -489,7 +489,7 @@ const Design: React.FC = () => {
   const [uploadedFile, setUploadedFile] = useState<{name: string; url: string; fileKey: string; size: number; isPdf: boolean; thumbnailUrl?: string} | null>(null);
   const [uploadError, setUploadError] = useState('');
   const [activePreset, setActivePreset] = useState<number | null>(0);
-  const [quantity, setQuantity] = useState(1);
+  const [quantity, setQuantity] = useState(initialProductType === 'yard_sign' ? 10 : 1);
   const [promoCode, setPromoCode] = useState('');
   const [promoApplied, setPromoApplied] = useState(false);
 
@@ -2035,7 +2035,7 @@ const Design: React.FC = () => {
               onClick={scrollToOrder}
               className="group inline-flex items-center justify-center gap-2 bg-orange-500 hover:bg-orange-600 active:scale-[0.98] text-white font-bold text-lg px-10 py-4 rounded-xl shadow-[0_4px_14px_rgba(251,146,60,0.4)] hover:shadow-[0_6px_20px_rgba(251,146,60,0.5)] transition-all w-full sm:w-auto"
             >
-              Upload &amp; Start Your Order →
+              Upload Design &amp; Continue
             </button>
           </div>
         </div>
@@ -2373,13 +2373,13 @@ const Design: React.FC = () => {
                   </p>
                 )}
                 {quantity === 1 && (
-                  <p className="text-xs text-gray-500 mt-1.5">Quantity 1 selected — continue when ready.</p>
+                  <p className="text-xs text-gray-500 mt-1.5">Use +/- to adjust quantity quickly.</p>
                 )}
                 {!isCarMagnet && quantity === 1 && (
                   <p className="text-xs text-gray-400 mt-1">Order 2+ for up to 13% off</p>
                 )}
               </ConfigCard>
-              <ConfigCard step={isCarMagnet ? 3 : 4} title={isCarMagnet ? 'Rounded Corners' : 'Finishing options'} id="options-section">
+              <ConfigCard step={isCarMagnet ? 3 : 4} title={isCarMagnet ? 'Rounded Corners' : 'More options'} id="options-section">
                 <div className="space-y-3">
                   {isCarMagnet ? (
                     <div>

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -227,7 +227,7 @@ const GoogleAdsBanner: React.FC = () => {
   const [uploadedFile, setUploadedFile] = useState<{name: string; url: string; fileKey: string; size: number; isPdf: boolean; thumbnailUrl?: string} | null>(null);
   const [uploadError, setUploadError] = useState('');
   const [activePreset, setActivePreset] = useState<number | null>(0);
-  const [quantity, setQuantity] = useState(1);
+  const [quantity, setQuantity] = useState(initialProductType === 'yard_sign' ? 10 : 1);
   const [promoCode, setPromoCode] = useState('');
   const [promoApplied, setPromoApplied] = useState(false);
 
@@ -733,7 +733,7 @@ const GoogleAdsBanner: React.FC = () => {
     setImgScaleY(restored.imgScaleY);
     setConstrainProps(restored.constrainProps);
     latestDesignRef.current = { ...restored };
-    setQuantity(1);
+    setQuantity(newType === 'yard_sign' ? 10 : 1);
     setPromoCode('');
     setPromoApplied(false);
     // Switching product tabs is a fresh start — clear confirmation flags so
@@ -1818,9 +1818,9 @@ const GoogleAdsBanner: React.FC = () => {
                 onClick={scrollToOrder}
                 className="group inline-flex items-center justify-center gap-2 bg-orange-500 hover:bg-orange-600 active:scale-[0.98] text-white font-bold text-lg px-10 py-4 rounded-xl shadow-[0_4px_14px_rgba(251,146,60,0.4)] hover:shadow-[0_6px_20px_rgba(251,146,60,0.5)] transition-all w-full sm:w-auto"
               >
-                Upload &amp; Start Your Order →
+                Upload Design &amp; Continue
               </button>
-              <span className="text-xs text-gray-200">Takes less than 60 seconds</span>
+              <div className="text-xs text-gray-200 text-center space-y-1"><p>Upload your design in minutes.</p><p>We review files before printing.</p><p>Printed within 24 hours and shipped free via next-day air.</p></div>
 
               {/* Trust bar */}
               <div className="mt-4 flex flex-col items-center gap-2">


### PR DESCRIPTION
### Motivation
- Reduce first-time builder friction and keep one dominant action visible so cold paid-traffic visitors move quickly toward upload, cart, and checkout. 
- Improve ordering clarity and urgency with concise reassurance copy near CTAs while preserving existing pricing/quote behavior. 
- Make card payments feel like a normal checkout option by clarifying that cards can be used via PayPal without mentioning or enabling Stripe.

### Description
- Updated the mobile builder step labels and sticky CTA flow to more action-oriented copy so the next step is unambiguous (`More options`, `Upload Design & Continue`) and advanced settings are de-emphasized. 
- Set smart defaults for yard signs by initializing quantity to 10 and resetting to 10 when switching to the yard-sign product tab while leaving pricing logic intact. 
- Tightened above-the-fold CTA and trust/urgency copy to encourage upload-first behavior and quick ordering, adding short lines like “Upload your design in minutes,” “We review files before printing,” and “Printed within 24 hours and shipped free via next-day air.” 
- Clarified checkout payment copy to explicitly state `Pay securely by card or PayPal. No PayPal account required.`, removed user-facing mentions of Stripe in the touched copy areas, and added a small reassurance line above PayPal buttons so card payment via PayPal reads like a native option. 
- Files updated: `src/lib/builderSteps.ts`, `src/pages/Design.tsx`, `src/pages/GoogleAdsBanner.tsx`, `src/components/HeroSection.tsx`, `src/pages/Checkout.tsx`, and `src/components/checkout/PayPalCheckout.tsx`. 
- Risks & follow-ups: verify spacing/layout for the new PayPal reassurance line across breakpoints in a quick browser QA pass, and consider adding an explicit “increments of 10” helper inside the yard-sign quantity UI as a follow-up A/B test.

### Testing
- Ran `npm run build` and the production build completed successfully with no build errors. 
- No automated unit tests were changed or run as part of this PR beyond the successful build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe959ae9588333854543fafa7eb0ce)