### PR TITLE
Fix Google OAuth callback state validation and sign-in error visibility

### DIFF
--- a/netlify/functions/google-callback.ts
+++ b/netlify/functions/google-callback.ts
@@ -120,6 +120,17 @@ export const handler: Handler = async (event) => {
 
     // Step 3: Create or update user in database
     const dbUrl = process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL;
+    if (!dbUrl) {
+      console.error('Database URL is not configured for Google OAuth callback');
+      return {
+        statusCode: 302,
+        headers: {
+          Location: '/sign-in?error=' + encodeURIComponent('Server authentication configuration error'),
+        },
+        body: '',
+      };
+    }
+
     const sql = neon(dbUrl);
 
     const normalizedEmail = googleUser.email?.toLowerCase();
@@ -253,6 +264,15 @@ export const handler: Handler = async (event) => {
   </div>
   <script>
     try {
+      const expectedState = sessionStorage.getItem('google_oauth_state');
+      const callbackState = ${JSON.stringify(state || '')};
+
+      if (!expectedState || !callbackState || expectedState !== callbackState) {
+        throw new Error('Invalid OAuth state. Please try signing in again.');
+      }
+
+      sessionStorage.removeItem('google_oauth_state');
+
       const user = ${JSON.stringify(safeUser)};
       console.log('✅ Google OAuth: Storing user in localStorage:', user);
       localStorage.setItem('banners_current_user', JSON.stringify(user));

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -68,6 +68,17 @@ const SignIn: React.FC = () => {
   // }, [user, authLoading, navigate, nextUrl]);
 
   useEffect(() => {
+    const oauthError = searchParams.get('error');
+    if (oauthError) {
+      toast({
+        title: 'Google Sign-In Failed',
+        description: decodeURIComponent(oauthError),
+        variant: 'destructive',
+      });
+    }
+  }, [searchParams, toast]);
+
+  useEffect(() => {
     scrollToTop();
     if (titleRef.current) {
       setTimeout(() => {


### PR DESCRIPTION
### Motivation
- Harden the Google OAuth flow by validating the CSRF `state` before persisting a session to prevent session-mixup or CSRF issues. 
- Ensure callback failures caused by missing deployment configuration (DB URL / OAuth envs) return a deterministic error redirect instead of crashing. 
- Improve user and developer visibility by surfacing OAuth callback errors on the sign-in page so failures are actionable. 

### Description
- Added a guard in `netlify/functions/google-callback.ts` that checks `NETLIFY_DATABASE_URL` / `DATABASE_URL` and returns a deterministic redirect with an `error` query when the DB URL is missing. 
- Added CSRF `state` validation in the callback completion HTML script in `netlify/functions/google-callback.ts` to compare `sessionStorage.google_oauth_state` with the callback `state`, throw on mismatch, and remove the stored state after successful validation. 
- Added user-facing error handling to `src/pages/SignIn.tsx` to read `?error=` from the query string and show a destructive toast so OAuth callback errors are visible immediately. 
- Files changed: `netlify/functions/google-callback.ts` and `src/pages/SignIn.tsx`. 

### Testing
- Built the frontend with `npm run -s build` and the build completed successfully (production build succeeded; non-blocking warnings about Browserslist and CSS minification were observed). 
- Verified there were no TypeScript/build errors after the changes and committed the updates; automated build step passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9ae4b4888333a847cfdb18a45c74)