### PR TITLE
Fix OAuth callback/session validation issues breaking admin and checkout loads

### DIFF
--- a/netlify/functions/google-callback.ts
+++ b/netlify/functions/google-callback.ts
@@ -120,6 +120,9 @@ export const handler: Handler = async (event) => {
 
     // Step 3: Create or update user in database
     const dbUrl = process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL;
+    if (!dbUrl) {
+      throw new Error('Database not configured. Missing NETLIFY_DATABASE_URL or DATABASE_URL.');
+    }
     const sql = neon(dbUrl);
 
     const normalizedEmail = googleUser.email?.toLowerCase();
@@ -254,66 +257,44 @@ export const handler: Handler = async (event) => {
   <script>
     try {
       const user = ${JSON.stringify(safeUser)};
-      console.log('✅ Google OAuth: Storing user in localStorage:', user);
+      const redirectBase = '/';
+
+      const buildRedirectUrl = (path, params = {}) => {
+        const nextUrl = new URL(path || redirectBase, window.location.origin);
+        Object.entries(params).forEach(([k, v]) => {
+          if (v !== undefined && v !== null && v !== '') nextUrl.searchParams.set(k, String(v));
+        });
+        return nextUrl.pathname + nextUrl.search;
+      };
+
+      const callbackState = ${JSON.stringify(state || '')};
+      const storedState = sessionStorage.getItem('google_oauth_state');
+      if (!callbackState || !storedState || callbackState !== storedState) {
+        throw new Error('Security validation failed. Please try signing in again.');
+      }
+      sessionStorage.removeItem('google_oauth_state');
+
       localStorage.setItem('banners_current_user', JSON.stringify(user));
-      
-      // Verify storage was successful
       const stored = localStorage.getItem('banners_current_user');
-      if (!stored) {
-        throw new Error('Failed to store user in localStorage');
-      }
-      
-      console.log('✅ Google OAuth: User stored successfully, verified');
-      
-      // CRITICAL FIX: Dispatch user-changed event to trigger cart reload
-      // This ensures the cart loads immediately for Google OAuth users
-      // (Manual login already does this in auth.ts signIn() function)
-      console.log('🔔 Google OAuth: Dispatching user-changed event to trigger cart reload');
+      if (!stored) throw new Error('Failed to store user in localStorage');
+
       window.dispatchEvent(new Event('user-changed'));
-      window.dispatchEvent(new StorageEvent('storage', {
-        key: 'banners_current_user',
-        newValue: JSON.stringify(user),
-        oldValue: null,
-        storageArea: localStorage,
-        url: window.location.href
-      }));
-      console.log('✅ Google OAuth: Events dispatched successfully');
-      
-      // Check for checkout context to determine redirect
-      let redirectUrl = '/?oauth=success&provider=google';
-      try {
-        const checkoutContext = localStorage.getItem('checkout-context-storage');
-        if (checkoutContext) {
-          const context = JSON.parse(checkoutContext);
-          if (context?.state?.isInCheckoutFlow && context?.state?.returnUrl) {
-            const contextAge = Date.now() - (context.state.contextSetAt || 0);
-            const maxAge = 30 * 60 * 1000; // 30 minutes
-            
-            if (contextAge < maxAge) {
-              redirectUrl = context.state.returnUrl + '?oauth=success&provider=google';
-              console.log('✅ Google OAuth: Checkout context found, redirecting to:', redirectUrl);
-              
-              // Clear checkout context after using it
-              localStorage.removeItem('checkout-context-storage');
-            } else {
-              console.log('⏰ Google OAuth: Checkout context expired, using default redirect');
-            }
-          }
-        }
-      } catch (e) {
-        console.error('❌ Google OAuth: Error checking checkout context:', e);
+
+      let redirectUrl = buildRedirectUrl('/', { oauth: 'success', provider: 'google' });
+      const savedReturnUrl = sessionStorage.getItem('google_oauth_return_url');
+      if (savedReturnUrl) {
+        redirectUrl = buildRedirectUrl(savedReturnUrl, { oauth: 'success', provider: 'google' });
+        sessionStorage.removeItem('google_oauth_return_url');
       }
-      
-      console.log('✅ Google OAuth: Redirecting to:', redirectUrl);
-      
-      // Small delay to ensure localStorage is fully written and events are processed
-      setTimeout(() => {
-        window.location.replace(redirectUrl);
-      }, 250);
+
+      setTimeout(() => window.location.replace(redirectUrl), 200);
     } catch (error) {
-      console.error('❌ Google OAuth: Error storing user:', error);
-      alert('Error completing sign-in: ' + error.message);
-      window.location.replace('/sign-in?error=Failed to complete sign-in');
+      console.error('Google OAuth callback failed:', error);
+      sessionStorage.removeItem('google_oauth_state');
+      sessionStorage.removeItem('google_oauth_return_url');
+      const errorUrl = new URL('/sign-in', window.location.origin);
+      errorUrl.searchParams.set('error', error instanceof Error ? error.message : 'Failed to complete sign-in');
+      window.location.replace(errorUrl.pathname + errorUrl.search);
     }
   </script>
 </body>

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -11,9 +11,10 @@ import { useToast } from '@/components/ui/use-toast';
 interface GoogleButtonProps {
   mode?: 'signin' | 'signup';
   className?: string;
+  returnUrl?: string;
 }
 
-const GoogleButton: React.FC<GoogleButtonProps> = ({ mode = 'signin', className = '' }) => {
+const GoogleButton: React.FC<GoogleButtonProps> = ({ mode = 'signin', className = '', returnUrl }) => {
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
 
@@ -38,6 +39,16 @@ const GoogleButton: React.FC<GoogleButtonProps> = ({ mode = 'signin', className 
       if (!result.ok || !result.authUrl) {
         console.error('❌ Invalid response structure:', result);
         throw new Error(result.error || 'Failed to initiate Google sign-in');
+      }
+
+
+      // Preserve intended post-login return URL for callback processing
+      if (returnUrl) {
+        try {
+          sessionStorage.setItem('google_oauth_return_url', returnUrl);
+        } catch (storageError) {
+          console.warn('Could not persist Google OAuth return URL:', storageError);
+        }
       }
 
       // Store state for CSRF protection

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,7 +22,31 @@ class SecureAuthAdapter implements AuthAdapter {
   async getCurrentUser(): Promise<User | null> {
     try {
       const stored = safeStorage.getItem(this.CURRENT_USER_KEY);
-      let user = stored ? JSON.parse(stored) : null;
+      let user: User | null = null;
+
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          const parsedId = typeof parsed?.id === 'string' ? parsed.id.trim() : '';
+          const parsedEmail = typeof parsed?.email === 'string' ? parsed.email.trim() : '';
+
+          if (!parsedId || !parsedEmail) {
+            console.warn('Malformed stored user missing id/email; clearing banners_current_user');
+            safeStorage.removeItem(this.CURRENT_USER_KEY);
+          } else {
+            user = {
+              id: parsedId,
+              email: parsedEmail.toLowerCase(),
+              full_name: typeof parsed?.full_name === 'string' ? parsed.full_name : undefined,
+              username: typeof parsed?.username === 'string' ? parsed.username : undefined,
+              is_admin: parsed?.is_admin === true,
+            };
+          }
+        } catch (parseError) {
+          console.warn('Malformed JSON in banners_current_user; clearing value', parseError);
+          safeStorage.removeItem(this.CURRENT_USER_KEY);
+        }
+      }
 
       // Debug logging for production troubleshooting
       const hasAdminCookie = typeof document !== 'undefined' && document.cookie.includes('admin=1');

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -282,7 +282,7 @@ const SignIn: React.FC = () => {
 
             {/* LinkedIn Button */}
             <LinkedInButton />
-            <GoogleButton mode="signin" />
+            <GoogleButton mode="signin" returnUrl={getNextUrl()} />
           </div>
 
           {/* Footer */}


### PR DESCRIPTION
### Motivation
- Users were getting stuck after Google OAuth or seeing admin/checkout fail to load due to brittle callback redirect construction and missing CSRF/state validation. 
- The app assumed `banners_current_user` was always a valid JSON object, which allowed malformed localStorage to crash auth consumers during boot. 
- The intended post-login `returnUrl` was not reliably preserved across the OAuth round-trip, breaking returns to `/admin` and `/checkout` flows.

### Description
- Validate and protect the OAuth callback in `netlify/functions/google-callback.ts`: add a DB URL guard, validate `state` against `sessionStorage`, remove state after use, write a restricted `safeUser` to `banners_current_user`, dispatch `user-changed`, and build redirect URLs with the `URL` API instead of string concatenation. (`netlify/functions/google-callback.ts`)
- Preserve the desired post-login return URL by passing `returnUrl` from the sign-in page into the Google button and storing it in `sessionStorage` as `google_oauth_return_url` so the callback can restore it. (`src/pages/SignIn.tsx`, `src/components/auth/GoogleButton.tsx`)
- Harden global auth parsing so `getCurrentUser()` safely parses `banners_current_user`, validates required fields (`id`, `email`), normalizes the shape, and clears malformed values instead of letting them throw during app boot. This prevents infinite spinners/crashes in admin/checkout consumers that read auth on startup. (`src/lib/auth.ts`)
- Small UX/robustness fixes in the callback page script to surface OAuth errors back to `/sign-in` in a consistent way and to clear temporary session keys on failure. (`netlify/functions/google-callback.ts`)

### Testing
- Ran a production build with `npm run build` (Vite production build) and it completed successfully (build completed). 
- Verified changes are limited to auth/OAuth/session handoff code by only modifying `netlify/functions/google-callback.ts`, `src/components/auth/GoogleButton.tsx`, `src/lib/auth.ts`, and `src/pages/SignIn.tsx`.
- No other automated tests were added or run beyond the successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9cb451c883338fb75a5c2fb20aa2)