### PR TITLE
Align recover-missing-order admin auth with shared session-based check

### DIFF
--- a/netlify/functions/recover-missing-order.cjs
+++ b/netlify/functions/recover-missing-order.cjs
@@ -1,6 +1,7 @@
 const { neon } = require('@neondatabase/serverless');
 const { randomUUID } = require('crypto');
 const { handler: notifyOrderHandler } = require('./notify-order.cjs');
+const { checkAdminAccess } = require('./lib/graduation.cjs');
 
 const headers = {
   'Access-Control-Allow-Origin': '*',
@@ -10,12 +11,6 @@ const headers = {
 };
 
 const toCents = (value) => Math.round((Number(value) || 0) * 100);
-
-async function isAdmin(sql, email) {
-  if (!email) return false;
-  const rows = await sql`SELECT is_admin FROM profiles WHERE LOWER(email)=LOWER(${email}) LIMIT 1`;
-  return rows.length > 0 && rows[0].is_admin === true;
-}
 
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
@@ -29,7 +24,15 @@ exports.handler = async (event) => {
     if (!dbUrl) return { statusCode: 500, headers, body: JSON.stringify({ ok: false, error: 'Database not configured' }) };
     const sql = neon(dbUrl);
 
-    if (!(await isAdmin(sql, adminEmail))) {
+    const authorized = await checkAdminAccess(event, sql, adminEmail);
+    if (!authorized) {
+      console.warn('[recover-missing-order] admin authorization denied', {
+        reason: 'checkAdminAccess returned false',
+        hasAuthorizationHeader: !!(event.headers?.authorization || event.headers?.Authorization),
+        hasCookieHeader: !!(event.headers?.cookie || event.headers?.Cookie),
+        adminEmailProvided: typeof adminEmail === 'string' && adminEmail.length > 0,
+        normalizedAdminEmail: typeof adminEmail === 'string' ? adminEmail.toLowerCase().trim() : null,
+      });
       return { statusCode: 403, headers, body: JSON.stringify({ ok: false, error: 'Admin authorization failed' }) };
     }
 


### PR DESCRIPTION
### Motivation
- The recovery endpoint was rejecting valid admin sessions because it only trusted an `adminEmail` POST field and performed a direct `profiles.is_admin` lookup instead of honoring the session/cookie-based admin signal used by the admin UI.
- This produced an auth drift where `/admin/orders` loaded successfully but `/recover-missing-order` returned `403 Admin authorization failed` for the same logged-in admin.

### Description
- Replaced the local DB-only `isAdmin` check in `netlify/functions/recover-missing-order.cjs` with the shared `checkAdminAccess(event, sql, email)` helper from `netlify/functions/lib/graduation.cjs` so the function now honors the `admin=1` cookie and the same DB/env allowlist logic as other admin endpoints.
- Removed the previous `isAdmin` implementation and added structured diagnostic logging on authorization denial (presence of Authorization header, Cookie header, provided adminEmail, and normalized email) to improve Netlify logs for debugging without relaxing security.
- Kept all existing validation and duplicate-detection logic intact and preserved the function's response semantics for success/failure.

### Testing
- Ran a full production build with `npm run build` which completed successfully without errors.
- Verified the updated function file `netlify/functions/recover-missing-order.cjs` compiles and the change was committed to the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa730865c8333a8da71c109137ccc)