### PR TITLE
Mobile UX flow update: directional CTAs + mobile auto-advance

### DIFF
--- a/src/lib/builderSteps.ts
+++ b/src/lib/builderSteps.ts
@@ -98,11 +98,11 @@ export interface BuilderProgress {
 }
 
 const STEP_LABELS: Record<BuilderStepKey, string> = {
-  size: 'Choose size',
-  material: 'Select material',
-  quantity: 'Choose quantity',
-  options: 'Choose options',
-  upload: 'Upload artwork',
+  size: 'Size',
+  material: 'Material',
+  quantity: 'Upload',
+  options: 'Finishing',
+  upload: 'Checkout',
 };
 
 /** Label rendered when every step is complete and Add-to-Cart is the next action. */
@@ -219,7 +219,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!isSizeValid(state)) {
     return {
       step: 'size',
-      label: 'Choose Size',
+      label: 'Continue to Material',
       scrollTargetId: STEP_ANCHORS.size,
       disabled: false,
       loading: false,
@@ -230,7 +230,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!isMaterialValid(state)) {
     return {
       step: 'material',
-      label: 'Select Material',
+      label: 'Continue to Upload',
       scrollTargetId: STEP_ANCHORS.material,
       disabled: false,
       loading: false,
@@ -241,7 +241,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!isQuantityValid(state)) {
     return {
       step: 'quantity',
-      label: 'Choose Quantity',
+      label: 'Continue to Finishing',
       scrollTargetId: STEP_ANCHORS.quantity,
       disabled: false,
       loading: false,
@@ -252,7 +252,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!isOptionsComplete(state)) {
     return {
       step: 'options',
-      label: 'More options',
+      label: 'Continue to Upload',
       scrollTargetId: STEP_ANCHORS.options,
       disabled: false,
       loading: false,
@@ -263,7 +263,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
   if (!state.hasUpload) {
     return {
       step: 'upload',
-      label: 'Upload Design & Continue',
+      label: 'Continue to Design',
       scrollTargetId: STEP_ANCHORS.upload,
       disabled: false,
       loading: false,
@@ -273,7 +273,7 @@ export function getNextStep(state: BuilderStepState): BuilderCtaDescriptor {
 
   return {
     step: 'add_to_cart',
-    label: 'Add to Cart',
+    label: 'Continue to Checkout',
     scrollTargetId: null,
     disabled: false,
     loading: false,

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -872,6 +872,11 @@ const Design: React.FC = () => {
     const target = builderStartRef.current ?? orderRef.current;
     target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
+  const autoAdvanceMobileStep = useCallback((nextAnchorId: string) => {
+    if (typeof window === 'undefined') return;
+    if (window.innerWidth >= 1024) return;
+    window.setTimeout(() => scrollToStepAnchor(nextAnchorId), 250);
+  }, []);
 
   useEffect(() => {
     const section = orderRef.current;
@@ -898,6 +903,7 @@ const Design: React.FC = () => {
     setHeightInRStr(String(p.h % 12));
     setActivePreset(idx);
     setHasConfirmedSize(true);
+    autoAdvanceMobileStep('material-section');
   };
 
   const handlePromoApply = () => {
@@ -2328,7 +2334,7 @@ const Design: React.FC = () => {
                             <button
                               key={m.key}
                               type="button"
-                              onClick={() => { setMaterial(m.mapped); setMaterialDropdownOpen(false); }}
+                              onClick={() => { setMaterial(m.mapped); setMaterialDropdownOpen(false); autoAdvanceMobileStep('upload-section'); }}
                               className={`w-full flex items-center gap-3 px-3 py-3 text-left transition-colors cursor-pointer ${
                                 m.mapped === material
                                   ? 'bg-orange-50 border-l-2 border-orange-500'
@@ -2359,11 +2365,11 @@ const Design: React.FC = () => {
               )}
               <ConfigCard step={isCarMagnet ? 2 : 3} title="Quantity" id="quantity-section">
                 <div className="flex items-center gap-3">
-                  <button onClick={() => setQuantity(q => Math.max(1, q - 1))} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
+                  <button onClick={() => { setQuantity(q => Math.max(1, q - 1)); autoAdvanceMobileStep('options-section'); }} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
                     <Minus className="h-4 w-4 text-gray-600" />
                   </button>
-                  <input type="number" min={1} max={999} value={quantity} onChange={e => setQuantity(Math.max(1, +e.target.value || 1))} className="w-20 border rounded-xl px-3 py-1.5 text-base text-center" />
-                  <button onClick={() => setQuantity(q => Math.min(999, q + 1))} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
+                  <input type="number" min={1} max={999} value={quantity} onChange={e => { setQuantity(Math.max(1, +e.target.value || 1)); autoAdvanceMobileStep('options-section'); }} className="w-20 border rounded-xl px-3 py-1.5 text-base text-center" />
+                  <button onClick={() => { setQuantity(q => Math.min(999, q + 1)); autoAdvanceMobileStep('options-section'); }} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
                     <Plus className="h-4 w-4 text-gray-600" />
                   </button>
                 </div>

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -679,6 +679,11 @@ const GoogleAdsBanner: React.FC = () => {
     const target = builderStartRef.current ?? orderRef.current;
     target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
+  const autoAdvanceMobileStep = useCallback((nextAnchorId: string) => {
+    if (typeof window === 'undefined') return;
+    if (window.innerWidth >= 1024) return;
+    window.setTimeout(() => scrollToStepAnchor(nextAnchorId), 250);
+  }, []);
 
   useEffect(() => {
     const section = orderRef.current;
@@ -774,6 +779,7 @@ const GoogleAdsBanner: React.FC = () => {
     setHeightInRStr(String(p.h % 12));
     setActivePreset(idx);
     setHasConfirmedSize(true);
+    autoAdvanceMobileStep('material-section');
   };
 
   const handlePromoApply = () => {
@@ -2111,7 +2117,7 @@ const GoogleAdsBanner: React.FC = () => {
                               <button
                                 key={m.key}
                                 type="button"
-                                onClick={() => { setMaterial(m.mapped); setMaterialDropdownOpen(false); }}
+                                onClick={() => { setMaterial(m.mapped); setMaterialDropdownOpen(false); autoAdvanceMobileStep('upload-section'); }}
                                 className={`w-full flex items-center gap-3 px-3 py-3 text-left transition-colors cursor-pointer ${
                                   m.mapped === material
                                     ? 'bg-orange-50 border-l-2 border-orange-500'
@@ -2146,11 +2152,11 @@ const GoogleAdsBanner: React.FC = () => {
                   <>
                 <ConfigCard step={3} title="Quantity" id="quantity-section">
                   <div className="flex items-center gap-3">
-                    <button onClick={() => setQuantity(q => Math.max(1, q - 1))} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
+                    <button onClick={() => { setQuantity(q => Math.max(1, q - 1)); autoAdvanceMobileStep('options-section'); }} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
                       <Minus className="h-4 w-4 text-gray-600" />
                     </button>
-                    <input type="number" min={1} max={999} value={quantity} onChange={e => setQuantity(Math.max(1, +e.target.value || 1))} className="w-20 border rounded-xl px-3 py-1.5 text-base text-center" />
-                    <button onClick={() => setQuantity(q => Math.min(999, q + 1))} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
+                    <input type="number" min={1} max={999} value={quantity} onChange={e => { setQuantity(Math.max(1, +e.target.value || 1)); autoAdvanceMobileStep('options-section'); }} className="w-20 border rounded-xl px-3 py-1.5 text-base text-center" />
+                    <button onClick={() => { setQuantity(q => Math.min(999, q + 1)); autoAdvanceMobileStep('options-section'); }} className="w-9 h-9 flex items-center justify-center border border-gray-200 rounded-xl hover:border-gray-400 transition-colors">
                       <Plus className="h-4 w-4 text-gray-600" />
                     </button>
                   </div>


### PR DESCRIPTION
### Motivation
- Reduce mobile user confusion where preselected options still required tapping a confirmation CTA by making the CTA describe the next step and auto-advancing after selections on mobile.
- Provide a unified mobile-first progression for all configurator flows (banners, yard signs, car magnets) while preserving desktop layout and behaviour.

### Description
- Replaced confirmation-oriented step labels with directional progression copy in the shared step machine (`src/lib/builderSteps.ts`), e.g. `Continue to Material`, `Continue to Upload`, `Continue to Design`, and `Continue to Checkout`, and shortened step indicator labels to `Size`, `Material`, `Upload`, `Finishing`, `Checkout`.
- Added a mobile-only (viewport < 1024px) auto-advance helper (`autoAdvanceMobileStep`) to `/design` and `/google-ads-banner` pages that triggers a smooth scroll to the next section after a ~250ms delay when users select size presets, choose a material, or change quantity.
- Wired the auto-advance into key interactions: `applyPreset`, material selection buttons, and quantity +/- / direct input handlers so selecting an option saves state and moves the user forward without requiring a second confirmation tap.
- Preserved all existing pricing, upload, cart, and state logic; the sticky bottom CTA remains as a visible fallback/navigation control and was not removed.

### Testing
- Ran the local typecheck script (`npm run -s typecheck`), which exited non-zero in this environment and did not produce a passing typecheck result due to local environment constraints.
- Attempted a local build (`npm run -s build`), which failed in this environment because the `vite` binary was not available (`vite: not found`).
- No automated unit/integration tests were modified; runtime QA should validate mobile smooth-scrolling, CTA labels, and that pricing/upload/cart flows are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a80c02d88333815523bad7218fbd)