### PR TITLE
Lightly brighten hero imagery and soften dark overlays

### DIFF
--- a/src/lib/heroBackground.ts
+++ b/src/lib/heroBackground.ts
@@ -7,7 +7,7 @@ import type { CSSProperties } from 'react';
  * autoplaying video.
  */
 export const HERO_BG_IMAGE_URL =
-  'https://res.cloudinary.com/dtrxl120u/image/upload/v1778430298/8072d966-0283-4b44-b972-4964edf3351a_n2fxia.png';
+  'https://res.cloudinary.com/dtrxl120u/image/upload/e_brightness:10,e_shadow:12/v1778430298/8072d966-0283-4b44-b972-4964edf3351a_n2fxia.png';
 
 /**
  * Inline style applying the hero image with a dark overlay so foreground
@@ -15,7 +15,7 @@ export const HERO_BG_IMAGE_URL =
  * or an absolutely-positioned background `<div>`.
  */
 export const heroBackgroundStyle: CSSProperties = {
-  backgroundImage: `linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.58)), url("${HERO_BG_IMAGE_URL}")`,
+  backgroundImage: `linear-gradient(rgba(0,0,0,0.38), rgba(0,0,0,0.52)), url("${HERO_BG_IMAGE_URL}")`,
   backgroundSize: 'cover',
   backgroundPosition: 'center center',
   backgroundRepeat: 'no-repeat',

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -1996,7 +1996,7 @@ const Design: React.FC = () => {
         <div
           className="absolute inset-0 z-[1]"
           style={{
-            background: 'linear-gradient(to bottom, rgba(0,0,0,0.55), rgba(0,0,0,0.35))',
+            background: 'linear-gradient(to bottom, rgba(0,0,0,0.48), rgba(0,0,0,0.30))',
           }}
           aria-hidden="true"
         />

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -1743,7 +1743,7 @@ const GoogleAdsBanner: React.FC = () => {
           <div
             className="absolute inset-0 z-[1]"
             style={{
-              background: 'linear-gradient(to bottom, rgba(0,0,0,0.55), rgba(0,0,0,0.35))',
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.48), rgba(0,0,0,0.30))',
             }}
             aria-hidden="true"
           />

--- a/src/pages/GraduationSigns.tsx
+++ b/src/pages/GraduationSigns.tsx
@@ -472,7 +472,7 @@ const GraduationSigns: React.FC = () => {
           className="absolute inset-0 bg-cover bg-center sm:bg-right"
           style={{
             backgroundImage:
-              "url('https://res.cloudinary.com/dtrxl120u/image/upload/v1777023371/hero_tbmims.png')",
+              "url('https://res.cloudinary.com/dtrxl120u/image/upload/e_brightness:12,e_shadow:12/v1777023371/hero_tbmims.png')",
           }}
           aria-hidden="true"
         />
@@ -481,7 +481,7 @@ const GraduationSigns: React.FC = () => {
           className="absolute inset-0"
           style={{
             background:
-              'linear-gradient(to right, rgba(11,31,58,0.92) 0%, rgba(11,31,58,0.88) 35%, rgba(11,31,58,0.65) 55%, rgba(11,31,58,0.2) 75%, rgba(11,31,58,0) 100%)',
+              'linear-gradient(to right, rgba(11,31,58,0.86) 0%, rgba(11,31,58,0.80) 35%, rgba(11,31,58,0.58) 55%, rgba(11,31,58,0.18) 75%, rgba(11,31,58,0) 100%)',
           }}
           aria-hidden="true"
         />

--- a/src/pages/PoliticalSigns.tsx
+++ b/src/pages/PoliticalSigns.tsx
@@ -77,11 +77,11 @@ const PoliticalSigns: React.FC = () => {
           className="absolute inset-0 bg-cover bg-center sm:bg-right"
           style={{
             backgroundImage:
-              "url('https://res.cloudinary.com/dtrxl120u/image/upload/v1778177853/political_banners_cdgdgp.png')",
+              "url('https://res.cloudinary.com/dtrxl120u/image/upload/e_brightness:10,e_shadow:10/v1778177853/political_banners_cdgdgp.png')",
           }}
           aria-hidden="true"
         />
-        <div className="absolute inset-0 bg-[#0B1F3A]/75" aria-hidden="true" />
+        <div className="absolute inset-0 bg-[#0B1F3A]/68" aria-hidden="true" />
         <div className="relative z-[2] max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-20 sm:py-24 lg:py-28">
           <div className="max-w-2xl">
             <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tight leading-tight text-white">


### PR DESCRIPTION
### Motivation
- Improve background visibility and perceived clarity in hero sections while preserving the premium dark cinematic aesthetic. 
- Reduce the feeling of an overly heavy/opaque overlay so product details (printers, banners, signs, vehicle graphics) are more legible. 
- Keep headline/CTA contrast and the orange CTAs visually dominant while subtly surfacing midtones and detail.

### Description
- Reduced the global hero overlay opacity in `src/lib/heroBackground.ts` by changing the gradient from `rgba(0,0,0,0.45)/rgba(0,0,0,0.58)` to `rgba(0,0,0,0.38)/rgba(0,0,0,0.52)` to slightly lift shadows/midtones while preserving blacks. 
- Added subtle Cloudinary tonal transforms to shared and product-specific hero image URLs using `e_brightness` and `e_shadow` parameters in `src/lib/heroBackground.ts`, `src/pages/GraduationSigns.tsx`, and `src/pages/PoliticalSigns.tsx` to increase background image brightness (~8–15% max) without washing highlights. 
- Softened secondary overlay gradients on `src/pages/Design.tsx` and `src/pages/GoogleAdsBanner.tsx` by reducing the overlay opacities from `0.55/0.35` to `0.48/0.30` for a less heavy overlay layer. 
- Tuned `GraduationSigns` left-to-right gradient stops and reduced the `PoliticalSigns` flat overlay opacity (`bg-[#0B1F3A]/75 -> /68`) to surface more background detail while keeping text readability and the dark mood.

### Testing
- Ran `npm run -s typecheck` in this environment and it exited non-zero (typecheck could not be validated here). 
- Attempted `npm run -s build`, which failed because `vite` is not available in this environment (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b6329a9883338bbebc49c7d6b5ed)