### PR TITLE
Enhance hero cinematic contrast and readability overlays

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Star, Lock, CheckCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { heroBackgroundStyle } from '@/lib/heroBackground';
+import { heroBackgroundStyle, heroCinematicOverlayStyle } from '@/lib/heroBackground';
 
 const HeroSection: React.FC = () => {
   const navigate = useNavigate();
@@ -18,6 +18,12 @@ const HeroSection: React.FC = () => {
       className="relative w-full overflow-hidden bg-slate-950 py-14 sm:py-16 md:py-20 lg:py-24"
       style={heroBackgroundStyle}
     >
+      <div className="absolute inset-0 z-[1]" style={heroCinematicOverlayStyle} aria-hidden="true" />
+      <div
+        className="absolute left-1/2 top-[35%] h-[420px] w-[780px] -translate-x-1/2 -translate-y-1/2 rounded-full z-[1]"
+        style={{ background: 'radial-gradient(circle, rgba(255,255,255,0.1) 0%, rgba(2,6,23,0) 70%)' }}
+        aria-hidden="true"
+      />
       <div className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div
           className="rounded-2xl border border-white/10 bg-black/15 p-6 sm:p-10 md:p-12 lg:p-16 backdrop-blur-[1px]"

--- a/src/lib/heroBackground.ts
+++ b/src/lib/heroBackground.ts
@@ -7,7 +7,7 @@ import type { CSSProperties } from 'react';
  * autoplaying video.
  */
 export const HERO_BG_IMAGE_URL =
-  'https://res.cloudinary.com/dtrxl120u/image/upload/e_brightness:10,e_shadow:12/v1778430298/8072d966-0283-4b44-b972-4964edf3351a_n2fxia.png';
+  'https://res.cloudinary.com/dtrxl120u/image/upload/e_brightness:20,e_contrast:8,e_shadow:28,e_blackwhite:10,co_rgb:111111,e_colorize:8/e_sharpen:35/v1778430298/8072d966-0283-4b44-b972-4964edf3351a_n2fxia.png';
 
 /**
  * Inline style applying the hero image with a dark overlay so foreground
@@ -15,8 +15,17 @@ export const HERO_BG_IMAGE_URL =
  * or an absolutely-positioned background `<div>`.
  */
 export const heroBackgroundStyle: CSSProperties = {
-  backgroundImage: `linear-gradient(rgba(0,0,0,0.38), rgba(0,0,0,0.52)), url("${HERO_BG_IMAGE_URL}")`,
+  backgroundImage: `linear-gradient(rgba(0,0,0,0.24), rgba(0,0,0,0.36)), url("${HERO_BG_IMAGE_URL}")`,
   backgroundSize: 'cover',
   backgroundPosition: 'center center',
   backgroundRepeat: 'no-repeat',
+};
+
+export const heroCinematicOverlayStyle: CSSProperties = {
+  background: [
+    'radial-gradient(62% 52% at 50% 32%, rgba(255, 171, 94, 0.16) 0%, rgba(255, 171, 94, 0.06) 34%, rgba(0,0,0,0) 66%)',
+    'radial-gradient(96% 82% at 50% 46%, rgba(15, 23, 42, 0.44) 0%, rgba(15, 23, 42, 0.54) 48%, rgba(2, 6, 23, 0.7) 100%)',
+    'linear-gradient(120deg, rgba(2,6,23,0.72) 0%, rgba(2,6,23,0.44) 42%, rgba(2,6,23,0.6) 100%)',
+    'linear-gradient(to bottom, rgba(0,0,0,0.44) 0%, rgba(0,0,0,0.22) 38%, rgba(0,0,0,0.45) 100%)',
+  ].join(','),
 };

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -8,7 +8,7 @@ import { useCartStore, type CartItem } from '@/store/cart';
 import { useUIStore } from '@/store/ui';
 import { calcTotals, usd, PRICE_PER_SQFT } from '@/lib/pricing';
 import { DESIGN_GROMMET_OPTIONS } from '@/lib/grommets';
-import { heroBackgroundStyle } from '@/lib/heroBackground';
+import { heroBackgroundStyle, heroCinematicOverlayStyle } from '@/lib/heroBackground';
 import UpsellModal, { UpsellOption } from '@/components/cart/UpsellModal';
 import {
   calculateBannerPricing,
@@ -1995,12 +1995,15 @@ const Design: React.FC = () => {
       >
         <div
           className="absolute inset-0 z-[1]"
-          style={{
-            background: 'linear-gradient(to bottom, rgba(0,0,0,0.48), rgba(0,0,0,0.30))',
-          }}
+          style={heroCinematicOverlayStyle}
           aria-hidden="true"
         />
-        <div className="relative z-[2] max-w-2xl mx-auto text-center space-y-4">
+        <div
+          className="absolute left-1/2 top-[34%] h-[340px] w-[640px] -translate-x-1/2 -translate-y-1/2 rounded-full z-[1] md:hidden"
+          style={{ background: 'radial-gradient(circle, rgba(255,255,255,0.12) 0%, rgba(2,6,23,0) 70%)' }}
+          aria-hidden="true"
+        />
+        <div className="relative z-[2] max-w-2xl mx-auto text-center space-y-4 rounded-2xl px-2 py-4 sm:px-6 sm:py-6 bg-black/18 backdrop-blur-[1.8px]">
           <h1 className="text-white text-3xl sm:text-4xl md:text-5xl font-black tracking-tight leading-tight">
             Design Your
             <br />

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -7,7 +7,7 @@ import { useCartStore, type CartItem } from '@/store/cart';
 import { useUIStore } from '@/store/ui';
 import { calcTotals, usd, PRICE_PER_SQFT } from '@/lib/pricing';
 import { calculateBannerPricing, type RopePlacement } from '@/lib/bannerPricingEngine';
-import { heroBackgroundStyle } from '@/lib/heroBackground';
+import { heroBackgroundStyle, heroCinematicOverlayStyle } from '@/lib/heroBackground';
 import { resolvePromo } from '@/lib/promoEngine';
 import { DESIGN_GROMMET_OPTIONS } from '@/lib/grommets';
 import UpsellModal, { UpsellOption } from '@/components/cart/UpsellModal';
@@ -1742,12 +1742,15 @@ const GoogleAdsBanner: React.FC = () => {
         >
           <div
             className="absolute inset-0 z-[1]"
-            style={{
-              background: 'linear-gradient(to bottom, rgba(0,0,0,0.48), rgba(0,0,0,0.30))',
-            }}
+            style={heroCinematicOverlayStyle}
             aria-hidden="true"
           />
-          <div className="relative z-[2] max-w-2xl mx-auto text-center space-y-5">
+          <div
+            className="absolute left-1/2 top-[34%] h-[340px] w-[640px] -translate-x-1/2 -translate-y-1/2 rounded-full z-[1] md:hidden"
+            style={{ background: 'radial-gradient(circle, rgba(255,255,255,0.14) 0%, rgba(2,6,23,0) 68%)' }}
+            aria-hidden="true"
+          />
+          <div className="relative z-[2] max-w-2xl mx-auto text-center space-y-5 rounded-2xl px-2 py-4 sm:px-6 sm:py-6 bg-black/20 backdrop-blur-[1.8px]">
             <h1 className="text-white text-3xl sm:text-4xl md:text-5xl font-black tracking-tight leading-tight">
               {isYardSign ? 'Custom Yard Signs' : isCarMagnet ? 'Design Your Custom Car Magnets' : 'Custom Banner Printing'}
               <br />


### PR DESCRIPTION
### Motivation
- Improve visibility of print-shop environment and product details in the shared hero image while preserving the moody, cinematic vignette and warm highlights.
- Increase midtone exposure, shadow detail, and product clarity so banners, yard signs, vinyl rolls, printers, and vehicle graphics read better without changing layout, typography, or replacing the hero image.

### Description
- Tuned the shared hero image URL in `src/lib/heroBackground.ts` to apply Cloudinary adjustments (`brightness`, `contrast`, `shadow`, `sharpen`, and subtle color treatment) and reduced the base dark overlay opacity.
- Added a reusable layered cinematic overlay `heroCinematicOverlayStyle` (vignette + directional darkening + warm center glow) in `src/lib/heroBackground.ts` and used it across hero sections.
- Applied the new overlay and a subtle radial glow / localized blurred dark backing to hero text in `src/components/HeroSection.tsx`, `src/pages/Design.tsx`, and `src/pages/GoogleAdsBanner.tsx` to boost text and CTA readability while keeping the premium moody look.
- Preserved all layout and typography; changes are limited to background image treatment, overlay gradients, and text-readability backing (no design or layout refactor). 

### Testing
- Ran `npm run -s lint`, which failed in this environment due to a missing dependency (`@eslint/js`) unrelated to the hero changes.
- Verified modified files and created the commit after local verification using `git status --short` and a normal commit; the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b8e13bf88333afadf112b546c32c)