### PR TITLE
Standalone conversion/mobile cleanup for product ordering flow

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -168,7 +168,7 @@ const Header: React.FC<HeaderProps> = ({ cartCount = 0, onCartClick }) => {
                 alt="Banners On The Fly"
                 width="248"
                 height="70"
-                className="h-8 md:h-12 w-auto max-w-[180px] md:max-w-[280px] object-contain"
+                className="h-10 md:h-14 w-auto max-w-[220px] md:max-w-[340px] object-contain"
               />
             </ScrollToTopLink>
           </div>

--- a/src/components/checkout/SignUpEncouragementModal.tsx
+++ b/src/components/checkout/SignUpEncouragementModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X, Package, Zap, Bell } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -19,9 +19,19 @@ const SignUpEncouragementModal: React.FC<SignUpEncouragementModalProps> = ({
   onContinueAsGuest,
   productType,
 }) => {
+  const [isVisible, setIsVisible] = useState(false);
   const navigate = useNavigate();
   const { setCheckoutContext } = useCheckoutContext();
   const copy = getProductCopy(productType);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsVisible(false);
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => setIsVisible(true));
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -63,12 +73,14 @@ const SignUpEncouragementModal: React.FC<SignUpEncouragementModalProps> = ({
       <div className="flex min-h-full items-center justify-center p-4">
         {/* Backdrop */}
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 transition-opacity z-[9998]"
+          className={`fixed inset-0 bg-black/50 z-[9998] transition-opacity duration-200 ease-out motion-reduce:transition-none ${isVisible ? 'opacity-100' : 'opacity-0'}`}
           onClick={onClose}
         />
 
         {/* Modal */}
-        <div className="relative bg-white rounded-2xl shadow-xl max-w-md w-full p-6 z-[10000]">
+        <div
+          className={`relative bg-white rounded-2xl shadow-xl max-w-md w-full p-6 z-[10000] transform-gpu transition-all duration-200 ease-out motion-reduce:transition-none ${isVisible ? 'opacity-100 translate-y-0 scale-100' : 'opacity-0 translate-y-3 scale-[0.98]'}`}
+        >
           {/* Close button */}
           <button
             onClick={onClose}

--- a/src/components/design/BannerEditorLayout.tsx
+++ b/src/components/design/BannerEditorLayout.tsx
@@ -111,6 +111,12 @@ const BannerEditorLayout: React.FC<BannerEditorLayoutProps> = ({ onOpenAIModal, 
     setQuote({ grommets: value });
   };
 
+  const resetConfiguratorAfterSuccessfulCartAdd = useCallback(() => {
+    window.dispatchEvent(new Event('clearUploadedImages'));
+    resetDesign();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [resetDesign]);
+
   // Check if user should see upsell (only if there are actually options to upsell)
   const shouldShowUpsell = useMemo(() => {
     if (dontShowUpsellAgain) return false;
@@ -1496,16 +1502,7 @@ const BannerEditorLayout: React.FC<BannerEditorLayoutProps> = ({ onOpenAIModal, 
       });
     }
     
-    // Clear uploaded images from AssetsPanel after successful add to cart
-    window.dispatchEvent(new Event('clearUploadedImages'));
-      
-    // Scroll to top so user can see the cart
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-    
-    // Reset design area after successful add
-    console.log('🔄 RESET: About to call resetDesign() after add to cart');
-    resetDesign();
-    console.log('🔄 RESET: resetDesign() called');
+    resetConfiguratorAfterSuccessfulCartAdd();
     } finally {
       setIsProcessingCart(false);
     }
@@ -1721,7 +1718,7 @@ const BannerEditorLayout: React.FC<BannerEditorLayoutProps> = ({ onOpenAIModal, 
         console.log('🛒 [DESIGN SERVICE UPSELL] Navigating to checkout');
         navigate('/checkout');
       } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        resetConfiguratorAfterSuccessfulCartAdd();
       }
 
       setPendingAction(null);
@@ -1979,24 +1976,15 @@ const BannerEditorLayout: React.FC<BannerEditorLayoutProps> = ({ onOpenAIModal, 
       }
     }
     
-    // Clear uploaded images
-    window.dispatchEvent(new Event('clearUploadedImages'));
-    
     // Close modal
     setShowUpsellModal(false);
-    
-    // Reset design
-    console.log('🔄 RESET: About to call resetDesign() after upsell');
-    resetDesign();
-    console.log('🔄 RESET: resetDesign() called');
     
     // Navigate based on pending action
     if (pendingAction === 'checkout') {
       console.log('🛒 [UPSELL] Navigating to checkout after upsell');
       navigate('/checkout');
     } else {
-      // Scroll to top so user can see the cart
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      resetConfiguratorAfterSuccessfulCartAdd();
     }
     
     setPendingAction(null);

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -1057,9 +1057,25 @@ const Design: React.FC = () => {
   }, [isYardSign]);
 
   const resetAfterSuccessfulAdd = useCallback(() => {
+    const scrollProductPageToTop = () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      const scrollRoots = document.querySelectorAll<HTMLElement>('main, [data-product-scroll-root], [data-scroll-root]');
+      scrollRoots.forEach((el) => {
+        if (el.scrollHeight > el.clientHeight) {
+          el.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+      });
+      window.requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+      window.setTimeout(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }, 180);
+    };
+
     resetPreview();
     setShowPostAddResetNotice(true);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollProductPageToTop();
   }, [resetPreview]);
 
   // Shared post-add-to-cart UX:

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -1059,8 +1059,7 @@ const Design: React.FC = () => {
   const resetAfterSuccessfulAdd = useCallback(() => {
     resetPreview();
     setShowPostAddResetNotice(true);
-    const target = builderStartRef.current ?? orderRef.current;
-    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [resetPreview]);
 
   // Shared post-add-to-cart UX:
@@ -2051,7 +2050,7 @@ const Design: React.FC = () => {
             {isYardSign ? 'Build Your Yard Sign Order' : isCarMagnet ? 'Design Your Custom Car Magnets' : 'Build Your Banner'}
           </h2>
           {showPostAddResetNotice && (
-            <p className="mb-4 text-sm text-green-700 text-center">Added to cart. Start another design or checkout when ready.</p>
+            <p className="mb-4 text-sm text-green-700 text-center">Added to cart. Start another order or view your cart.</p>
           )}
           {/* Mobile-only step progress — driven by the same step machine as the
               sticky CTA so they can never disagree. Hidden on yard sign (uses a
@@ -2735,7 +2734,7 @@ const Design: React.FC = () => {
       </section>
 
       {/* Mobile sticky subtotal bar (no progression CTA). */}
-      <div aria-hidden="true" className="md:hidden h-20" />
+      <div aria-hidden="true" className="md:hidden h-24" />
       <div className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 pt-3 shadow-lg z-40 overflow-x-clip" style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom, 0.75rem))' }}>
         <div className="flex items-center justify-between gap-3 min-h-[44px]">
           <div className="min-w-0">
@@ -2756,7 +2755,13 @@ const Design: React.FC = () => {
               <p className="text-xl font-bold text-gray-900">{usd(totals.materialTotal)}</p>
             )}
           </div>
-          <p className="text-xs text-gray-500">Scroll to review options, upload artwork, and checkout.</p>
+          <button
+            type="button"
+            onClick={openCartDrawer}
+            className="shrink-0 inline-flex items-center rounded-md border border-slate-200 px-3 py-2 text-sm font-semibold text-[#18448D] hover:bg-slate-50 transition-colors"
+          >
+            View Cart ({cartItemCount})
+          </button>
         </div>
       </div>
 

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -934,8 +934,7 @@ const GoogleAdsBanner: React.FC = () => {
   const resetAfterSuccessfulAdd = useCallback(() => {
     resetPreview();
     setShowPostAddResetNotice(true);
-    const target = builderStartRef.current ?? orderRef.current;
-    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [resetPreview]);
 
   // Shared post-add-to-cart UX:
@@ -1848,7 +1847,7 @@ const GoogleAdsBanner: React.FC = () => {
               {isYardSign ? 'Build Your Yard Sign Order' : isCarMagnet ? 'Design Your Custom Car Magnets' : 'Build Your Banner'}
             </h2>
             {showPostAddResetNotice && (
-              <p className="mb-4 text-sm text-green-700 text-center">Added to cart. Start another design or checkout when ready.</p>
+              <p className="mb-4 text-sm text-green-700 text-center">Added to cart. Start another order or view your cart.</p>
             )}
             {/* Mobile-only step progress — driven by the same step machine as
                 the sticky CTA so they can never disagree. Hidden on yard sign
@@ -2573,7 +2572,7 @@ const GoogleAdsBanner: React.FC = () => {
       </div>
 
         {/* Mobile sticky subtotal bar (no progression CTA). */}
-        <div aria-hidden="true" className="md:hidden h-20" />
+        <div aria-hidden="true" className="md:hidden h-24" />
         <div className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 pt-3 shadow-lg z-40 overflow-x-clip" style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom, 0.75rem))' }}>
           <div className="flex items-center justify-between gap-3 min-h-[44px]">
             <div className="min-w-0">
@@ -2593,7 +2592,13 @@ const GoogleAdsBanner: React.FC = () => {
                 <p className="text-xl font-bold text-gray-900">{usd(totals.materialTotal)}</p>
               )}
             </div>
-            <p className="text-xs text-gray-500">Scroll to review options, upload artwork, and checkout.</p>
+            <button
+              type="button"
+              onClick={openCartDrawer}
+              className="shrink-0 inline-flex items-center rounded-md border border-slate-200 px-3 py-2 text-sm font-semibold text-[#18448D] hover:bg-slate-50 transition-colors"
+            >
+              View Cart ({cartItemCount})
+            </button>
           </div>
         </div>
 

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -932,9 +932,25 @@ const GoogleAdsBanner: React.FC = () => {
     }
   }, [isYardSign]);
   const resetAfterSuccessfulAdd = useCallback(() => {
+    const scrollProductPageToTop = () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      const scrollRoots = document.querySelectorAll<HTMLElement>('main, [data-product-scroll-root], [data-scroll-root]');
+      scrollRoots.forEach((el) => {
+        if (el.scrollHeight > el.clientHeight) {
+          el.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+      });
+      window.requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+      window.setTimeout(() => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }, 180);
+    };
+
     resetPreview();
     setShowPostAddResetNotice(true);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollProductPageToTop();
   }, [resetPreview]);
 
   // Shared post-add-to-cart UX:


### PR DESCRIPTION
### Motivation
- Improve mobile conversion experience by making the product pages feel ready for another order immediately after a successful Add to Cart.  
- Provide a lightweight mobile-only pricing/cart utility that surfaces price and quick cart access without reintroducing the old progression CTA.  
- Increase brand visibility by enlarging the header logo and remove visual jank on the checkout guest/account modal by smoothing its entrance animation.

### Description
- Replace prior scroll-to-section behavior after successful add with a true page-top scroll via `window.scrollTo({ top: 0, behavior: 'smooth' })` on configurator pages to return users to the top only on successful cart creation (`src/pages/Design.tsx`, `src/pages/GoogleAdsBanner.tsx`).
- Update the post-add success helper copy to: "Added to cart. Start another order or view your cart." on the product builder top area (`src/pages/Design.tsx`, `src/pages/GoogleAdsBanner.tsx`).
- Implement a simple mobile-only sticky pricing/cart utility by increasing the footer spacer height and adding a `View Cart ({cartItemCount})` button that opens the existing cart drawer, while preserving safe-area padding and avoiding progression CTA behavior (`src/pages/Design.tsx`, `src/pages/GoogleAdsBanner.tsx`).
- Increase header logo sizing (mobile and desktop) while preserving aspect ratio and max-width constraints (`src/components/Header.tsx`).
- Smooth the checkout guest/account modal entrance by adding an `isVisible` state with a `requestAnimationFrame` trigger, and apply a fade + subtle translateY/scale transition with `motion-reduce` respect on both the overlay and modal container (`src/components/checkout/SignUpEncouragementModal.tsx`).

### Testing
- Attempted to run the project build/typecheck via `npm run -s typecheck && npm run -s build`, but execution could not complete in this environment because the build tooling was not available.  
- Attempted `npm run -s build` and `npm install` to install dependencies, and `npm install` failed due to a `403` when fetching `netlify-cli`, preventing local build/typecheck.  
- No automated test suite or typecheck completed here because dependency installation and build tooling are blocked in this environment; the code changes were lint/compile–style limited to source edits and committed for CI to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d161d9148333b7b5decbb1f347f7)