### PR TITLE
Block indexing on Netlify preview and branch deploy environments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -198,3 +198,32 @@
 [[edge_functions]]
   path = "/graduation-signs"
   function = "social-meta-injector"
+
+# Preview/branch deploy crawler protection
+[context.deploy-preview]
+  command = "npm run build"
+
+[[context.deploy-preview.headers]]
+  for = "/*"
+  [context.deploy-preview.headers.values]
+  X-Robots-Tag = "noindex, nofollow, noarchive, nosnippet, noimageindex"
+
+[[context.deploy-preview.redirects]]
+  from = "/robots.txt"
+  to = "/robots-preview.txt"
+  status = 200
+  force = true
+
+[context.branch-deploy]
+  command = "npm run build"
+
+[[context.branch-deploy.headers]]
+  for = "/*"
+  [context.branch-deploy.headers.values]
+  X-Robots-Tag = "noindex, nofollow, noarchive, nosnippet, noimageindex"
+
+[[context.branch-deploy.redirects]]
+  from = "/robots.txt"
+  to = "/robots-preview.txt"
+  status = 200
+  force = true

--- a/public/robots-preview.txt
+++ b/public/robots-preview.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,6 +12,11 @@ Allow: /
 
 User-agent: *
 Allow: /
+Disallow: /admin
+Disallow: /admin/
+Disallow: /admin/*
+Disallow: /proof
+Disallow: /proof/
 
 # Sitemap
 Sitemap: https://bannersonthefly.com/sitemap.xml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,14 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
+import { Helmet } from "react-helmet-async";
 import { ThemeProvider } from "@/components/theme-provider";
 import { useCartSync } from "@/hooks/useCartSync";
 import { useCartRevalidation } from "@/hooks/useCartRevalidation";
 import { useCartStore } from "@/store/cart";
 import { toast } from "@/components/ui/use-toast";
 import { initPostHog } from "@/lib/posthog";
+import { isPreviewEnvironment } from "@/lib/environment";
 // DISABLED: Popup promo flow replaced with static NEW20 code in PromoBanner
 // import { PromoPopup } from "@/components/PromoPopup";
 // import { usePromoPopup } from "@/hooks/usePromoPopup";
@@ -140,8 +142,19 @@ const CartSyncWrapper = ({ children }: { children: React.ReactNode }) => {
 
 const queryClient = new QueryClient();
 
+const PreviewNoindexGuard = () => {
+  if (!isPreviewEnvironment()) return null;
+
+  return (
+    <Helmet>
+      <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noimageindex" />
+    </Helmet>
+  );
+};
+
 const App = () => (
   <HelmetProvider>
+  <PreviewNoindexGuard />
   <ThemeProvider defaultTheme="light">
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -1,0 +1,35 @@
+const PRODUCTION_HOSTS = new Set([
+  'bannersonthefly.com',
+  'www.bannersonthefly.com',
+]);
+
+const PREVIEW_CONTEXTS = new Set(['deploy-preview', 'branch-deploy']);
+
+function normalizeHost(hostname: string | null | undefined): string {
+  return (hostname || '').toLowerCase();
+}
+
+export function isProductionHost(hostname: string | null | undefined): boolean {
+  return PRODUCTION_HOSTS.has(normalizeHost(hostname));
+}
+
+export function isPreviewEnvironment(hostname?: string | null): boolean {
+  const host = normalizeHost(hostname ?? (typeof window !== 'undefined' ? window.location.hostname : ''));
+
+  if (isProductionHost(host)) return false;
+
+  // Netlify preview host patterns
+  if (host.includes('deploy-preview')) return true;
+  if (host.includes('--') && host.endsWith('.netlify.app')) return true;
+
+  // Netlify build context hints (if surfaced in env vars)
+  const rawContext =
+    (typeof import.meta !== 'undefined' && (import.meta as any).env?.CONTEXT) ||
+    (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_NETLIFY_CONTEXT) ||
+    (typeof process !== 'undefined' ? process.env?.CONTEXT : undefined) ||
+    (typeof process !== 'undefined' ? process.env?.NETLIFY_CONTEXT : undefined);
+
+  const context = String(rawContext || '').toLowerCase();
+  return PREVIEW_CONTEXTS.has(context);
+}
+


### PR DESCRIPTION
### Motivation
- Prevent deploy-preview/branch-deploy Netlify sites from being indexed or crawled because real traffic was hitting preview URLs that must be treated as staging. 
- Provide a centralized, auditable preview-detection and noindex mechanism so the behavior is not scattered across components. 

### Description
- Add `src/lib/environment.ts` with `isPreviewEnvironment()` and `isProductionHost()` to centralize host/context detection and explicitly exempt `bannersonthefly.com` and `www.bannersonthefly.com`. 
- Inject a global preview-only robots meta tag from the app shell via a `PreviewNoindexGuard` in `src/App.tsx` that adds `<meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noimageindex">` when a preview is detected. 
- Update `netlify.toml` to scope headers/redirects for Netlify `deploy-preview` and `branch-deploy` contexts so all responses include `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet, noimageindex` and `/robots.txt` is redirected to a preview-specific `robots-preview.txt`. 
- Add `public/robots-preview.txt` that disallows all crawling and update `public/robots.txt` to keep normal production sitemap behavior while explicitly disallowing sensitive paths (`/admin`, `/admin/*`, `/proof`, `/proof/`). 
- Keep changes narrowly focused on preview/crawler/indexing protection and do not alter checkout, cart, product pages, admin auth, or unrelated UI. 

### Testing
- Attempted automated build with `npm run build` in this environment, which failed because `vite` is not available here (`sh: 1: vite: not found`).
- No other automated tests were run in this environment; runtime verification of headers/meta/robots should be validated in Netlify deploy previews where the `deploy-preview` / `branch-deploy` contexts are active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00dff547bc83338ebec465ae04f492)