### PR TITLE
Add preview-only app password gate

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,84 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { isPreviewEnvironment, isProductionHost } from './lib/environment';
 
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+const PREVIEW_SESSION_KEY = 'preview_access_granted';
 
-// Remove dark mode class addition
-createRoot(document.getElementById("root")!).render(<App />);
-// FORCE REBUILD 1758737918
+function PreviewAccessGate() {
+  const expectedPassword = import.meta.env.VITE_PREVIEW_ACCESS_PASSWORD;
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const isConfigured = useMemo(() => {
+    return typeof expectedPassword === 'string' && expectedPassword.length > 0;
+  }, [expectedPassword]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!isConfigured) {
+      return;
+    }
+
+    if (password === expectedPassword) {
+      sessionStorage.setItem(PREVIEW_SESSION_KEY, 'true');
+      window.location.reload();
+      return;
+    }
+
+    setErrorMessage('Invalid preview password.');
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-100 px-4">
+      <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-xl font-semibold text-slate-900">Preview Access</h1>
+        <p className="mt-2 text-sm text-slate-600">Enter the password to continue.</p>
+
+        {!isConfigured ? (
+          <p className="mt-4 text-sm font-medium text-red-600">Preview access is not configured.</p>
+        ) : (
+          <form className="mt-4 space-y-3" onSubmit={handleSubmit}>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => {
+                setPassword(event.target.value);
+                setErrorMessage('');
+              }}
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              autoComplete="current-password"
+              placeholder="Password"
+            />
+            <button
+              type="submit"
+              className="w-full rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800"
+            >
+              Enter Preview
+            </button>
+            {errorMessage ? <p className="text-sm text-red-600">{errorMessage}</p> : null}
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function shouldRequirePreviewGate(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const hostname = window.location.hostname;
+  if (isProductionHost(hostname)) return false;
+  if (!isPreviewEnvironment(hostname)) return false;
+
+  const hasAccess = sessionStorage.getItem(PREVIEW_SESSION_KEY) === 'true';
+  return !hasAccess;
+}
+
+const RootComponent = shouldRequirePreviewGate() ? PreviewAccessGate : App;
+
+createRoot(document.getElementById('root')!).render(<RootComponent />);
+
 import './buildId';
-// Force deployment 1759256333


### PR DESCRIPTION
### Motivation
- Prevent public access to Netlify deploy-preview and branch-deploy URLs by requiring an app-level password before the main React app renders.
- Reuse existing environment helpers so production hosts remain unaffected and the gate applies only to preview contexts.

### Description
- Adds a preview access gate in `src/main.tsx` that chooses `PreviewAccessGate` vs `App` before calling `createRoot`, so the main app/routes are not rendered until access is granted.
- Uses `isPreviewEnvironment()` and `isProductionHost()` from `src/lib/environment.ts` to ensure the gate only appears on preview environments and is never shown for `bannersonthefly.com` or `www.bannersonthefly.com`.
- Validates password against `VITE_PREVIEW_ACCESS_PASSWORD` (no hardcoded secret and the password is not logged) and shows `Preview access is not configured.` when the env var is missing.
- Stores successful access in `sessionStorage` only (no `localStorage`) so the same tab/session remains unlocked on refresh while new/incognito tabs require the password again, and admin authentication remains separate and still required after preview access.

### Testing
- Ran `npm run build`; it failed in this environment because `vite` is not available on PATH (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e1e84ac083339a8a9c61ee09164f)