### PR TITLE
Fix preview access password env resolution for Netlify deploy previews

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,10 +6,39 @@ import { isPreviewEnvironment, isProductionHost } from './lib/environment';
 
 const PREVIEW_SESSION_KEY = 'preview_access_granted';
 
+declare global {
+  interface Window {
+    __ENV__?: {
+      VITE_PREVIEW_ACCESS_PASSWORD?: string;
+    };
+  }
+}
+
+function getPreviewAccessPassword(): string {
+  const vitePassword = import.meta.env.VITE_PREVIEW_ACCESS_PASSWORD;
+
+  if (typeof vitePassword === 'string' && vitePassword.length > 0) {
+    return vitePassword;
+  }
+
+  if (typeof window !== 'undefined') {
+    const runtimePassword = window.__ENV__?.VITE_PREVIEW_ACCESS_PASSWORD;
+    if (typeof runtimePassword === 'string' && runtimePassword.length > 0) {
+      return runtimePassword;
+    }
+  }
+
+  return '';
+}
+
 function PreviewAccessGate() {
-  const expectedPassword = import.meta.env.VITE_PREVIEW_ACCESS_PASSWORD;
+  const expectedPassword = getPreviewAccessPassword();
   const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+
+  if (isPreviewEnvironment()) {
+    console.log('[preview-gate] env present:', !!expectedPassword);
+  }
 
   const isConfigured = useMemo(() => {
     return typeof expectedPassword === 'string' && expectedPassword.length > 0;


### PR DESCRIPTION
### Motivation
- Deploy previews were resolving `import.meta.env.VITE_PREVIEW_ACCESS_PASSWORD` as `undefined` at runtime because runtime envs set by Netlify are not always present at Vite build-time, causing the preview access gate to incorrectly report unconfigured access.

### Description
- Keep primary lookup on `import.meta.env.VITE_PREVIEW_ACCESS_PASSWORD` but move lookup into a runtime function `getPreviewAccessPassword()` so the value is read in valid runtime scope rather than at module initialization.
- Add a safe runtime fallback to `window.__ENV__.VITE_PREVIEW_ACCESS_PASSWORD` to support Netlify runtime-injected envs or manual `window.__ENV__` injection when `import.meta.env` is unavailable.
- Add preview-only boolean presence debug logging `console.log('[preview-gate] env present:', !!expectedPassword)` and ensure no secret value is logged and no trimming or alternate env names are used.
- Preserve existing production bypass behavior and preview gating logic so production hosts remain unaffected.

### Testing
- Attempted a production build with `npm run build` which failed in this environment due to `vite` not being available on PATH (`sh: 1: vite: not found`).
- No automated unit/integration tests were executed in this environment after the change due to the local build limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e522c2748333a747ea52f479ba9e)