### PR TITLE
Remove extra helper text from Graduation product chooser

### DIFF
--- a/src/pages/GraduationSigns.tsx
+++ b/src/pages/GraduationSigns.tsx
@@ -678,10 +678,6 @@ const GraduationSigns: React.FC = () => {
                 >
                   Open the {PRODUCT_LABELS[uploadProduct]} Builder <ArrowRight className="h-5 w-5" />
                 </button>
-                <p className="mt-3 text-sm text-gray-500">
-                  Uses our existing builder, cart, upsell, PayPal checkout, admin order, and print-file
-                  pipeline.
-                </p>
               </div>
             </div>
           )}


### PR DESCRIPTION
### Motivation
- Remove an unnecessary helper sentence under the "Open the … Builder" CTA to keep the Graduation product chooser focused and reduce clutter.

### Description
- Deleted the `<p>` block containing the builder/cart/checkout pipeline helper text in `src/pages/GraduationSigns.tsx` so only the product selection and CTA remain.

### Testing
- No automated tests were run for this content-only change; repository state and the change were verified with `git status --short` showing a clean working tree after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0231f82f408333856bc9d12de84381)