### PR TITLE
Always render finishing option rows with None fallback across UI and emails

### DIFF
--- a/netlify/functions/email-template.cjs
+++ b/netlify/functions/email-template.cjs
@@ -131,7 +131,7 @@ function renderItems(items = []) {
                     ${item.stepStakesQty ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Step Stakes: ${Number(item.stepStakesQty)}</p>` : ''}
                     <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Grommets: ${escapeHtml(item.grommetsDisplay || 'None')}</p>
                     <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Pole Pockets: ${escapeHtml(item.polePocketsDisplay || 'None')}</p>
-                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rope Hemming: ${escapeHtml(item.ropeDisplay || 'None')}</p><p style="margin:0 0 2px;color:#64748b;font-size:12px;">Hemming: Included</p>
+                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rope: ${escapeHtml(item.ropeDisplay || 'None')}</p><p style="margin:0 0 2px;color:#64748b;font-size:12px;">Hemming: Always included</p>
                     ${item.roundedCornersDisplay ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rounded Corners: ${escapeHtml(item.roundedCornersDisplay)}</p>` : ''}
                     ${lineTotal > 0 ? `<p style="margin:0 0 2px;color:${BRAND_NAVY};font-size:13px;font-weight:600;">Unit Price: $${unitPrice.toFixed(2)}</p>` : ''}
                     ${lineTotal > 0 ? `<p style="margin:0;color:${BRAND_ORANGE};font-size:14px;font-weight:700;">Line Total: $${lineTotal.toFixed(2)}</p>` : ''}

--- a/netlify/functions/email-template.cjs
+++ b/netlify/functions/email-template.cjs
@@ -129,9 +129,9 @@ function renderItems(items = []) {
                     <p style="margin:0 0 4px;color:#475569;font-size:13px;">Qty: ${quantity}</p>
                     ${item.uploadedDesignsCount ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Uploaded Designs: ${Number(item.uploadedDesignsCount)}</p>` : ''}
                     ${item.stepStakesQty ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Step Stakes: ${Number(item.stepStakesQty)}</p>` : ''}
-                    ${item.grommetsDisplay ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Grommets: ${escapeHtml(item.grommetsDisplay)}</p>` : ''}
-                    ${item.polePocketsDisplay ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Pole Pockets: ${escapeHtml(item.polePocketsDisplay)}</p>` : ''}
-                    ${item.ropeDisplay ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rope: ${escapeHtml(item.ropeDisplay)}</p>` : ''}
+                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Grommets: ${escapeHtml(item.grommetsDisplay || 'None')}</p>
+                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Pole Pockets: ${escapeHtml(item.polePocketsDisplay || 'None')}</p>
+                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rope Hemming: ${escapeHtml(item.ropeDisplay || 'None')}</p><p style="margin:0 0 2px;color:#64748b;font-size:12px;">Hemming: Included</p>
                     ${item.roundedCornersDisplay ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rounded Corners: ${escapeHtml(item.roundedCornersDisplay)}</p>` : ''}
                     ${lineTotal > 0 ? `<p style="margin:0 0 2px;color:${BRAND_NAVY};font-size:13px;font-weight:600;">Unit Price: $${unitPrice.toFixed(2)}</p>` : ''}
                     ${lineTotal > 0 ? `<p style="margin:0;color:${BRAND_ORANGE};font-size:14px;font-weight:700;">Line Total: $${lineTotal.toFixed(2)}</p>` : ''}

--- a/netlify/functions/product-display-helpers.cjs
+++ b/netlify/functions/product-display-helpers.cjs
@@ -63,6 +63,16 @@ function getDisplayGrommets(value) {
   return map[key] || toTitleCase(key.replace(/-/g, ' '));
 }
 
+
+function formatOptionValue(value) {
+  if (typeof value === 'boolean') return value ? 'Included' : 'None';
+  const raw = String(value || '').trim();
+  if (!raw) return 'None';
+  const lower = raw.toLowerCase();
+  if (lower === 'none' || lower === 'false' || lower === 'null' || lower === 'undefined') return 'None';
+  return raw;
+}
+
 function getDisplayPlacement(value) {
   const raw = String(value || '').trim().toLowerCase();
   if (!raw || raw === 'none' || raw === 'false') return '';
@@ -152,9 +162,10 @@ function getEmailItemOptions(item) {
     `Material: ${normalized.materialDisplay}`,
     `Print: ${normalized.printDisplay}`,
     normalized.qtyDisplay ? `Qty: ${normalized.qtyDisplay}` : null,
-    normalized.grommetsDisplay ? `Grommets: ${normalized.grommetsDisplay}` : null,
-    normalized.ropeDisplay ? `Rope: ${normalized.ropeDisplay}` : null,
-    normalized.polePocketsDisplay ? `Pole Pockets: ${normalized.polePocketsDisplay}` : null,
+    `Grommets: ${formatOptionValue(normalized.grommetsDisplay)}`,
+    `Pole Pockets: ${formatOptionValue(normalized.polePocketsDisplay)}`,
+    `Rope Hemming: ${formatOptionValue(normalized.ropeDisplay)}`,
+    'Hemming: Included',
     item.design_service_enabled ? '⚡ Design Service Order' : null,
   ];
   return parts.filter(Boolean).join(' • ');
@@ -176,7 +187,7 @@ function normalizeOrderItemDisplay(item) {
   const ropePlacementLabel = getDisplayPlacement(item.rope_placement);
   const ropeDisplay = ropeFeet > 0
     ? (ropePlacementLabel || `${ropeFeet.toFixed(1)} ft`)
-    : '';
+    : 'None';
   const polePocketPositionRaw = String(item.pole_pocket_position || item.pole_pockets || '').trim();
   const hasPolePocket = polePocketPositionRaw && polePocketPositionRaw !== 'none' && polePocketPositionRaw !== 'false';
   const polePocketPlacementLabel = hasPolePocket
@@ -184,10 +195,10 @@ function normalizeOrderItemDisplay(item) {
     : '';
   const polePocketsDisplay = hasPolePocket
     ? `${polePocketPlacementLabel}${item.pole_pocket_size ? ` (${item.pole_pocket_size} inch)` : ''}`
-    : '';
+    : 'None';
   const stepStakesQty = Number(item.yard_sign_step_stakes_qty || 0);
   const uploadedDesignsCount = Number(item.yard_sign_design_count || 0);
-  const grommetsDisplay = getDisplayGrommets(item.grommets);
+  const grommetsDisplay = formatOptionValue(getDisplayGrommets(item.grommets));
 
   return {
     productType: isYardSign ? 'yard-sign' : (isCarMagnet ? 'car-magnet' : 'banner'),
@@ -215,9 +226,10 @@ function normalizeOrderItemDisplay(item) {
             roundedCornersDisplay: getCarMagnetRoundedCornersLabel(item.rounded_corners),
           }
       : {
-          ...(grommetsDisplay ? { grommetsDisplay } : {}),
-          ...(ropeDisplay ? { ropeDisplay } : {}),
-          ...(polePocketsDisplay ? { polePocketsDisplay } : {}),
+          grommetsDisplay,
+          ropeDisplay: formatOptionValue(ropeDisplay),
+          polePocketsDisplay: formatOptionValue(polePocketsDisplay),
+          hemmingDisplay: 'Included',
         }),
   };
 }
@@ -336,4 +348,5 @@ module.exports = {
   getPayPalDescription,
   getDisplayGrommets,
   getDisplayPlacement,
+  formatOptionValue,
 };

--- a/netlify/functions/product-display-helpers.cjs
+++ b/netlify/functions/product-display-helpers.cjs
@@ -164,8 +164,8 @@ function getEmailItemOptions(item) {
     normalized.qtyDisplay ? `Qty: ${normalized.qtyDisplay}` : null,
     `Grommets: ${formatOptionValue(normalized.grommetsDisplay)}`,
     `Pole Pockets: ${formatOptionValue(normalized.polePocketsDisplay)}`,
-    `Rope Hemming: ${formatOptionValue(normalized.ropeDisplay)}`,
-    'Hemming: Included',
+    `Rope: ${formatOptionValue(normalized.ropeDisplay)}`,
+    'Hemming: Always included',
     item.design_service_enabled ? '⚡ Design Service Order' : null,
   ];
   return parts.filter(Boolean).join(' • ');
@@ -229,7 +229,7 @@ function normalizeOrderItemDisplay(item) {
           grommetsDisplay,
           ropeDisplay: formatOptionValue(ropeDisplay),
           polePocketsDisplay: formatOptionValue(polePocketsDisplay),
-          hemmingDisplay: 'Included',
+          hemmingDisplay: 'Always included',
         }),
   };
 }
@@ -261,7 +261,7 @@ function truncatePayPalDescription(text, max = PAYPAL_DESCRIPTION_MAX) {
  * for inclusion in the PayPal order/receipt.
  *
  * Example: 'Banner - 96" × 24", 13oz Vinyl, Qty 1, Grommets: Every 2–3 Feet,
- *           Pole Pockets: None, Rope: None, Hemming: Included'
+ *           Pole Pockets: None, Rope: None, Hemming: Always included'
  */
 function buildBannerPayPalLine(item) {
   const size = getDisplaySize(item);
@@ -283,7 +283,7 @@ function buildBannerPayPalLine(item) {
     : 'None';
 
   const sizePart = size ? `${size}, ` : '';
-  return `Banner - ${sizePart}${material}, Qty ${qty}, Grommets: ${grommetsLabel}, Pole Pockets: ${polePocketsLabel}, Rope: ${ropeLabel}, Hemming: Included`;
+  return `Banner - ${sizePart}${material}, Qty ${qty}, Grommets: ${grommetsLabel}, Pole Pockets: ${polePocketsLabel}, Rope: ${ropeLabel}, Hemming: Always included`;
 }
 
 /**

--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -186,8 +186,8 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                             ...(normalized.stepStakesQty ? [{ label: 'Step Stakes', value: String(normalized.stepStakesQty) }] : []),
                             { label: 'Grommets', value: normalized.grommetsDisplay },
                             { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
-                            { label: 'Rope Hemming', value: normalized.ropeDisplay },
-                            { label: 'Hemming', value: normalized.hemmingDisplay || 'Included' },
+                            { label: 'Rope', value: normalized.ropeDisplay },
+                            { label: 'Hemming', value: normalized.hemmingDisplay || 'Always included' },
                             ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                           ]}
                           renderLargePreview={() => (
@@ -259,7 +259,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                         {normalized.stepStakesQty ? <p><span className="font-medium text-gray-700">Step Stakes:</span> {normalized.stepStakesQty}</p> : null}
                         <p><span className="font-medium text-gray-700">Grommets:</span> {normalized.grommetsDisplay}</p>
                         <p><span className="font-medium text-gray-700">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
-                        <p><span className="font-medium text-gray-700">Rope Hemming:</span> {normalized.ropeDisplay}</p>
+                        <p><span className="font-medium text-gray-700">Rope:</span> {normalized.ropeDisplay}</p>
                         {normalized.roundedCornersDisplay ? <p><span className="font-medium text-gray-700">Rounded Corners:</span> {normalized.roundedCornersDisplay}</p> : null}
                       </div>
 

--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -184,9 +184,10 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                             { label: 'Qty', value: normalized.qtyDisplay },
                             ...(normalized.uploadedDesignsCount ? [{ label: 'Uploaded Designs', value: String(normalized.uploadedDesignsCount) }] : []),
                             ...(normalized.stepStakesQty ? [{ label: 'Step Stakes', value: String(normalized.stepStakesQty) }] : []),
-                            ...(normalized.grommetsDisplay ? [{ label: 'Grommets', value: normalized.grommetsDisplay }] : []),
-                            ...(normalized.polePocketsDisplay ? [{ label: 'Pole Pockets', value: normalized.polePocketsDisplay }] : []),
-                            ...(normalized.ropeDisplay ? [{ label: 'Rope', value: normalized.ropeDisplay }] : []),
+                            { label: 'Grommets', value: normalized.grommetsDisplay },
+                            { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
+                            { label: 'Rope Hemming', value: normalized.ropeDisplay },
+                            { label: 'Hemming', value: normalized.hemmingDisplay || 'Included' },
                             ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                           ]}
                           renderLargePreview={() => (
@@ -256,9 +257,9 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                         <p><span className="font-medium text-gray-700">Qty:</span> {normalized.qtyDisplay}</p>
                         {normalized.uploadedDesignsCount ? <p><span className="font-medium text-gray-700">Uploaded Designs:</span> {normalized.uploadedDesignsCount}</p> : null}
                         {normalized.stepStakesQty ? <p><span className="font-medium text-gray-700">Step Stakes:</span> {normalized.stepStakesQty}</p> : null}
-                        {normalized.grommetsDisplay ? <p><span className="font-medium text-gray-700">Grommets:</span> {normalized.grommetsDisplay}</p> : null}
-                        {normalized.polePocketsDisplay ? <p><span className="font-medium text-gray-700">Pole Pockets:</span> {normalized.polePocketsDisplay}</p> : null}
-                        {normalized.ropeDisplay ? <p><span className="font-medium text-gray-700">Rope:</span> {normalized.ropeDisplay}</p> : null}
+                        <p><span className="font-medium text-gray-700">Grommets:</span> {normalized.grommetsDisplay}</p>
+                        <p><span className="font-medium text-gray-700">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
+                        <p><span className="font-medium text-gray-700">Rope Hemming:</span> {normalized.ropeDisplay}</p>
                         {normalized.roundedCornersDisplay ? <p><span className="font-medium text-gray-700">Rounded Corners:</span> {normalized.roundedCornersDisplay}</p> : null}
                       </div>
 

--- a/src/components/orders/OrderDetails.tsx
+++ b/src/components/orders/OrderDetails.tsx
@@ -961,9 +961,9 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order, trigger, onUploadFin
                       <p className="break-words">Qty: {normalized.qtyDisplay}</p>
                       {normalized.uploadedDesignsCount ? <p className="break-words">Uploaded Designs: {normalized.uploadedDesignsCount}</p> : null}
                       {normalized.stepStakesQty ? <p className="break-words">Step Stakes: {normalized.stepStakesQty}</p> : null}
-                      {normalized.grommetsDisplay ? <p className="break-words">Grommets: {normalized.grommetsDisplay}</p> : null}
-                      {normalized.polePocketsDisplay ? <p className="break-words">Pole Pockets: {normalized.polePocketsDisplay}</p> : null}
-                      {normalized.ropeDisplay ? <p className="break-words">Rope: {normalized.ropeDisplay}</p> : null}
+                      <p className="break-words">Grommets: {normalized.grommetsDisplay}</p>
+                      <p className="break-words">Pole Pockets: {normalized.polePocketsDisplay}</p>
+                      <p className="break-words">Rope Hemming: {normalized.ropeDisplay}</p>
                       {normalized.roundedCornersDisplay ? <p className="break-words">Rounded Corners: {normalized.roundedCornersDisplay}</p> : null}
                     </div>
 

--- a/src/components/orders/OrderDetails.tsx
+++ b/src/components/orders/OrderDetails.tsx
@@ -963,7 +963,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order, trigger, onUploadFin
                       {normalized.stepStakesQty ? <p className="break-words">Step Stakes: {normalized.stepStakesQty}</p> : null}
                       <p className="break-words">Grommets: {normalized.grommetsDisplay}</p>
                       <p className="break-words">Pole Pockets: {normalized.polePocketsDisplay}</p>
-                      <p className="break-words">Rope Hemming: {normalized.ropeDisplay}</p>
+                      <p className="break-words">Rope: {normalized.ropeDisplay}</p>
                       {normalized.roundedCornersDisplay ? <p className="break-words">Rounded Corners: {normalized.roundedCornersDisplay}</p> : null}
                     </div>
 

--- a/src/lib/product-display.ts
+++ b/src/lib/product-display.ts
@@ -51,6 +51,7 @@ export type NormalizedOrderItemDisplay = {
   grommetsDisplay?: string;
   polePocketsDisplay?: string;
   ropeDisplay?: string;
+  hemmingDisplay?: string;
   uploadedDesignsCount?: number;
   stepStakesQty?: number;
   stepStakesLine?: string;
@@ -111,6 +112,15 @@ export function getDisplayGrommets(value?: string | null): string {
     'right-side': 'Right Side Only',
   };
   return map[key] || toTitleCase(key.replace(/-/g, ' '));
+}
+
+export function formatOptionValue(value?: string | null | boolean): string {
+  if (typeof value === 'boolean') return value ? 'Included' : 'None';
+  const raw = String(value || '').trim();
+  if (!raw) return 'None';
+  const lower = raw.toLowerCase();
+  if (lower === 'none' || lower === 'false' || lower === 'null' || lower === 'undefined') return 'None';
+  return raw;
 }
 
 /**
@@ -293,13 +303,14 @@ export function getEmailItemOptions(item: {
   const parts: (string | null)[] = [
     `Size: ${getDisplaySize(item)}`,
     `Material: ${getDisplayMaterial(item) || '13oz Vinyl'}`,
-    getDisplayGrommets(item.grommets) ? `Grommets: ${getDisplayGrommets(item.grommets)}` : null,
-    ropePlacementLabel ? `Rope: ${ropePlacementLabel}` : null,
-    polePocketPlacementLabel
+    `Grommets: ${formatOptionValue(getDisplayGrommets(item.grommets))}`,
+    `Rope Hemming: ${formatOptionValue(ropePlacementLabel)}`,
+    `Pole Pockets: ${formatOptionValue(polePocketPlacementLabel
       ? `Pole Pockets: ${polePocketPlacementLabel}${item.pole_pocket_size ? ` (${item.pole_pocket_size} inch)` : ''}`
       : (item.pole_pockets && item.pole_pockets !== 'none' && item.pole_pockets !== 'false')
         ? 'Pole Pockets: Yes'
-        : null,
+        : '')}`.replace(/^Pole Pockets:\s*/, ''),
+    'Hemming: Included',
     item.design_service_enabled ? '⚡ Design Service Order' : null,
   ];
   return parts.filter(Boolean).join(' • ');
@@ -326,7 +337,7 @@ export function normalizeOrderItemDisplay(item: NormalizableOrderItem): Normaliz
   // order items that pre-date the rope_placement field.
   const ropeDisplay = ropeFeet > 0
     ? (ropePlacementLabel || `${ropeFeet.toFixed(1)} ft`)
-    : '';
+    : 'None';
   const polePocketPositionRaw = String(item.pole_pocket_position || item.pole_pockets || '').trim();
   const hasPolePocket = polePocketPositionRaw && polePocketPositionRaw !== 'none' && polePocketPositionRaw !== 'false';
   const polePocketPlacementLabel = hasPolePocket
@@ -334,7 +345,8 @@ export function normalizeOrderItemDisplay(item: NormalizableOrderItem): Normaliz
     : '';
   const polePocketsDisplay = hasPolePocket
     ? `${polePocketPlacementLabel}${item.pole_pocket_size ? ` (${item.pole_pocket_size} inch)` : ''}`
-    : '';
+    : 'None';
+  const grommetsDisplay = formatOptionValue(getDisplayGrommets(item.grommets));
   const stepStakesQty = Number(item.yard_sign_step_stakes_qty || 0);
   const uploadedDesignsCount = Number(item.yard_sign_design_count || 0);
 
@@ -386,11 +398,10 @@ export function normalizeOrderItemDisplay(item: NormalizableOrderItem): Normaliz
             roundedCornersDisplay: `${getCarMagnetRoundedCornersLabel(item.rounded_corners)} (Included Free)`,
           }
       : {
-          ...(getDisplayGrommets(item.grommets) ? { grommetsDisplay: getDisplayGrommets(item.grommets) } : {}),
-          ...(polePocketsDisplay
-            ? { polePocketsDisplay }
-            : {}),
-          ...(ropeDisplay ? { ropeDisplay } : {}),
+          grommetsDisplay,
+          polePocketsDisplay: formatOptionValue(polePocketsDisplay),
+          ropeDisplay: formatOptionValue(ropeDisplay),
+          hemmingDisplay: 'Included',
         }),
   };
 }

--- a/src/lib/product-display.ts
+++ b/src/lib/product-display.ts
@@ -304,13 +304,13 @@ export function getEmailItemOptions(item: {
     `Size: ${getDisplaySize(item)}`,
     `Material: ${getDisplayMaterial(item) || '13oz Vinyl'}`,
     `Grommets: ${formatOptionValue(getDisplayGrommets(item.grommets))}`,
-    `Rope Hemming: ${formatOptionValue(ropePlacementLabel)}`,
+    `Rope: ${formatOptionValue(ropePlacementLabel)}`,
     `Pole Pockets: ${formatOptionValue(polePocketPlacementLabel
       ? `Pole Pockets: ${polePocketPlacementLabel}${item.pole_pocket_size ? ` (${item.pole_pocket_size} inch)` : ''}`
       : (item.pole_pockets && item.pole_pockets !== 'none' && item.pole_pockets !== 'false')
         ? 'Pole Pockets: Yes'
         : '')}`.replace(/^Pole Pockets:\s*/, ''),
-    'Hemming: Included',
+    'Hemming: Always included',
     item.design_service_enabled ? '⚡ Design Service Order' : null,
   ];
   return parts.filter(Boolean).join(' • ');
@@ -401,7 +401,7 @@ export function normalizeOrderItemDisplay(item: NormalizableOrderItem): Normaliz
           grommetsDisplay,
           polePocketsDisplay: formatOptionValue(polePocketsDisplay),
           ropeDisplay: formatOptionValue(ropeDisplay),
-          hemmingDisplay: 'Included',
+          hemmingDisplay: 'Always included',
         }),
   };
 }

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -630,8 +630,8 @@ const Checkout: React.FC = () => {
                       ...(normalized.stepStakesQty ? [{ label: 'Step Stakes', value: String(normalized.stepStakesQty) }] : []),
                       { label: 'Grommets', value: normalized.grommetsDisplay },
                       { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
-                      { label: 'Rope Hemming', value: normalized.ropeDisplay },
-                      { label: 'Hemming', value: normalized.hemmingDisplay || 'Included' },
+                      { label: 'Rope', value: normalized.ropeDisplay },
+                      { label: 'Hemming', value: normalized.hemmingDisplay || 'Always included' },
                       ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                     ];
 

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -628,9 +628,10 @@ const Checkout: React.FC = () => {
                       { label: 'Print', value: normalized.printDisplay },
                       ...(normalized.uploadedDesignsCount ? [{ label: 'Uploaded Designs', value: String(normalized.uploadedDesignsCount) }] : []),
                       ...(normalized.stepStakesQty ? [{ label: 'Step Stakes', value: String(normalized.stepStakesQty) }] : []),
-                      ...(normalized.grommetsDisplay ? [{ label: 'Grommets', value: normalized.grommetsDisplay }] : []),
-                      ...(normalized.polePocketsDisplay ? [{ label: 'Pole Pockets', value: normalized.polePocketsDisplay }] : []),
-                      ...(normalized.ropeDisplay ? [{ label: 'Rope', value: normalized.ropeDisplay }] : []),
+                      { label: 'Grommets', value: normalized.grommetsDisplay },
+                      { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
+                      { label: 'Rope Hemming', value: normalized.ropeDisplay },
+                      { label: 'Hemming', value: normalized.hemmingDisplay || 'Included' },
                       ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                     ];
 

--- a/src/pages/OrderConfirmation.tsx
+++ b/src/pages/OrderConfirmation.tsx
@@ -196,7 +196,7 @@ const OrderConfirmation: React.FC = () => {
                           {normalized.stepStakesQty && <p>Step Stakes: {normalized.stepStakesQty}</p>}
                           <p>Grommets: {normalized.grommetsDisplay}</p>
                           <p>Pole Pockets: {normalized.polePocketsDisplay}</p>
-                          <p>Rope Hemming: {normalized.ropeDisplay}</p>
+                          <p>Rope: {normalized.ropeDisplay}</p>
                           {normalized.roundedCornersDisplay && <p>Rounded Corners: {normalized.roundedCornersDisplay}</p>}
                         </div>
 

--- a/src/pages/OrderConfirmation.tsx
+++ b/src/pages/OrderConfirmation.tsx
@@ -194,9 +194,9 @@ const OrderConfirmation: React.FC = () => {
                           <p>Qty: {normalized.qtyDisplay}</p>
                           {normalized.uploadedDesignsCount && <p>Uploaded Designs: {normalized.uploadedDesignsCount}</p>}
                           {normalized.stepStakesQty && <p>Step Stakes: {normalized.stepStakesQty}</p>}
-                          {normalized.grommetsDisplay && <p>Grommets: {normalized.grommetsDisplay}</p>}
-                          {normalized.polePocketsDisplay && <p>Pole Pockets: {normalized.polePocketsDisplay}</p>}
-                          {normalized.ropeDisplay && <p>Rope: {normalized.ropeDisplay}</p>}
+                          <p>Grommets: {normalized.grommetsDisplay}</p>
+                          <p>Pole Pockets: {normalized.polePocketsDisplay}</p>
+                          <p>Rope Hemming: {normalized.ropeDisplay}</p>
                           {normalized.roundedCornersDisplay && <p>Rounded Corners: {normalized.roundedCornersDisplay}</p>}
                         </div>
 

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -332,7 +332,7 @@ const OrderDetail: React.FC = () => {
                         )}
                         <p><span className="font-medium">Grommets:</span> {normalized.grommetsDisplay}</p>
                         <p><span className="font-medium">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
-                        <p><span className="font-medium">Rope Hemming:</span> {normalized.ropeDisplay}</p>
+                        <p><span className="font-medium">Rope:</span> {normalized.ropeDisplay}</p>
                         {normalized.roundedCornersDisplay && (
                           <p><span className="font-medium">Rounded Corners:</span> {normalized.roundedCornersDisplay}</p>
                         )}

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -330,15 +330,9 @@ const OrderDetail: React.FC = () => {
                         {normalized.stepStakesQty && (
                           <p><span className="font-medium">Step Stakes:</span> {normalized.stepStakesQty}</p>
                         )}
-                        {normalized.grommetsDisplay && (
-                          <p><span className="font-medium">Grommets:</span> {normalized.grommetsDisplay}</p>
-                        )}
-                        {normalized.polePocketsDisplay && (
-                          <p><span className="font-medium">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
-                        )}
-                        {normalized.ropeDisplay && (
-                          <p><span className="font-medium">Rope:</span> {normalized.ropeDisplay}</p>
-                        )}
+                        <p><span className="font-medium">Grommets:</span> {normalized.grommetsDisplay}</p>
+                        <p><span className="font-medium">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
+                        <p><span className="font-medium">Rope Hemming:</span> {normalized.ropeDisplay}</p>
                         {normalized.roundedCornersDisplay && (
                           <p><span className="font-medium">Rounded Corners:</span> {normalized.roundedCornersDisplay}</p>
                         )}

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -261,7 +261,7 @@ const PaymentSuccess: React.FC = () => {
                           {normalized.stepStakesQty ? <p className="text-sm text-gray-600">Step Stakes: {normalized.stepStakesQty}</p> : null}
                           <p className="text-sm text-gray-600">Grommets: {normalized.grommetsDisplay}</p>
                           <p className="text-sm text-gray-600">Pole Pockets: {normalized.polePocketsDisplay}</p>
-                          <p className="text-sm text-gray-600">Rope Hemming: {normalized.ropeDisplay}</p>
+                          <p className="text-sm text-gray-600">Rope: {normalized.ropeDisplay}</p>
 
                           {/* Cost Breakdown */}
                           <div className="mt-3 p-3 bg-gray-50 rounded-lg">

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -259,9 +259,9 @@ const PaymentSuccess: React.FC = () => {
                           </p>
                           {normalized.uploadedDesignsCount ? <p className="text-sm text-gray-600">Uploaded Designs: {normalized.uploadedDesignsCount}</p> : null}
                           {normalized.stepStakesQty ? <p className="text-sm text-gray-600">Step Stakes: {normalized.stepStakesQty}</p> : null}
-                          {normalized.grommetsDisplay ? <p className="text-sm text-gray-600">Grommets: {normalized.grommetsDisplay}</p> : null}
-                          {normalized.polePocketsDisplay ? <p className="text-sm text-gray-600">Pole Pockets: {normalized.polePocketsDisplay}</p> : null}
-                          {normalized.ropeDisplay ? <p className="text-sm text-gray-600">Rope: {normalized.ropeDisplay}</p> : null}
+                          <p className="text-sm text-gray-600">Grommets: {normalized.grommetsDisplay}</p>
+                          <p className="text-sm text-gray-600">Pole Pockets: {normalized.polePocketsDisplay}</p>
+                          <p className="text-sm text-gray-600">Rope Hemming: {normalized.ropeDisplay}</p>
 
                           {/* Cost Breakdown */}
                           <div className="mt-3 p-3 bg-gray-50 rounded-lg">


### PR DESCRIPTION
### Motivation
- Orders must explicitly show every finishing/add-on category for auditing and production clarity instead of hiding unset options.
- The system previously dropped empty/null/false finishing fields which made older orders ambiguous and inconsistent across emails, PDFs, admin UIs, and pages.
- Standardize formatting and labels for finishing options so every order displays the same set of rows and human-friendly values.

### Description
- Added a centralized formatter `formatOptionValue(value)` in `src/lib/product-display.ts` (and exported to `netlify/functions/product-display-helpers.cjs`) that returns the actual value or `'None'` for empty/null/false and maps booleans to `'Included'`/`'None'`.
- Normalized banner finishing fields in `normalizeOrderItemDisplay` so every item always emits `grommetsDisplay`, `polePocketsDisplay`, `ropeDisplay`, and `hemmingDisplay` with safe fallbacks for legacy orders.
- Updated backend helpers and email template (`netlify/functions/product-display-helpers.cjs` and `netlify/functions/email-template.cjs`) to always include finishing lines with the new formatting and to use the standardized labels `Grommets`, `Pole Pockets`, `Rope Hemming`, and `Hemming`.
- Updated multiple frontend renderers to stop conditionally hiding rows and instead render the standardized finishing rows exactly once: `src/pages/Checkout.tsx`, `src/pages/OrderConfirmation.tsx`, `src/pages/OrderDetail.tsx`, `src/pages/PaymentSuccess.tsx`, `src/components/CartModal.tsx`, and `src/components/orders/OrderDetails.tsx`.

### Testing
- Attempted an automated build with `npm run build`, which failed in this environment because `vite` is not installed here (`sh: 1: vite: not found`).
- No other automated test suites were executed in this run; code changes were validated by repository-wide search/inspection and by updating all template usages to the new normalized fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbefd4b548333b9459fea1c3742ea)