### PR TITLE
Disable retired CUSTOM60 discount code validation

### DIFF
--- a/netlify/functions/validate-discount-code.cjs
+++ b/netlify/functions/validate-discount-code.cjs
@@ -95,22 +95,15 @@ exports.handler = async (event, context) => {
     }
 
 
-    // SPECIAL HANDLING: CUSTOM60 guest-safe promotional code.
-    // This code intentionally does not depend on email/account presence.
+    // CUSTOM60 has been retired and should never validate.
     if (normalizedCode === 'CUSTOM60') {
-      console.log('[validate-discount-code] CUSTOM60 approved');
+      console.log('[validate-discount-code] CUSTOM60 rejected (retired code)');
       return {
-        statusCode: 200,
+        statusCode: 400,
         headers,
         body: JSON.stringify({
-          valid: true,
-          discount: {
-            id: 'CUSTOM60_PROMO',
-            code: 'CUSTOM60',
-            discountPercentage: 60,
-            discountAmountCents: null,
-            expiresAt: '2099-12-31T23:59:59Z'
-          }
+          valid: false,
+          error: 'Invalid discount code'
         })
       };
     }


### PR DESCRIPTION
### Motivation
- Prevent customers from applying the retired `CUSTOM60` promo at checkout by removing its hardcoded approval path. 
- Ensure promo validation flow falls back to standard DB-backed lookup for all non-special codes.

### Description
- Updated `netlify/functions/validate-discount-code.cjs` to change the `CUSTOM60` special-case from an approval to an explicit rejection. 
- The handler now logs `CUSTOM60 rejected (retired code)` and returns `400` with `{ valid: false, error: 'Invalid discount code' }` for `CUSTOM60`. 
- All other discount validation logic (e.g., `NEW20` handling and the DB lookup) remains unchanged.

### Testing
- Ran a repository search with `rg` to locate promo handlers and confirm the file to edit, which completed successfully. 
- Inspected the modified file with `sed -n '80,135p' netlify/functions/validate-discount-code.cjs` and verified the new `CUSTOM60` rejection block, which succeeded. 
- Confirmed the diff with `git diff -- netlify/functions/validate-discount-code.cjs` and committed the change with `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bce08edb88333afd2b3492ba90b57)