### PR TITLE
Unify finishing option display in designer pricing summary

### DIFF
--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -64,6 +64,7 @@ import {
   type BuilderStepKey,
 } from '@/lib/builderSteps';
 import { logUx } from '@/lib/uxAnalytics';
+import { formatOptionValue, getDisplayPlacement } from '@/lib/product-display';
 import { useAuth, isAdmin } from '@/lib/auth';
 
 const PRESET_SIZES = [
@@ -2590,13 +2591,10 @@ const Design: React.FC = () => {
                   secondaryLine={`for ${quantity} ${quantity === 1 ? 'banner' : 'banners'} • ${widthDisplay} × ${heightDisplay} • ${materialLabel}`}
                   showTopSummary={false}
                   detailRows={[
-                    { label: 'Grommets', value: grommetsLabel },
-                    ...(polePockets !== 'none'
-                      ? [{ label: `Pole Pockets (${polePockets})`, value: usd(bannerPricing.polePocketCostCents / 100) }]
-                      : []),
-                    ...(addRope
-                      ? [{ label: 'Rope', value: usd(bannerPricing.ropeCostCents / 100) }]
-                      : []),
+                    { label: 'Grommets', value: formatOptionValue(grommetsLabel) },
+                    { label: 'Pole Pockets', value: formatOptionValue(getDisplayPlacement(polePockets)) },
+                    { label: 'Rope Hemming', value: formatOptionValue(addRope ? getDisplayPlacement(ropePlacement) : '') },
+                    { label: 'Hemming', value: 'Always Included' },
                   ]}
                   baseSubtotalCents={bannerPricing.baseBannerPriceCents}
                   baseSubtotalLabel="Base banner"

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -71,6 +71,7 @@ import {
   type BuilderStepKey,
 } from '@/lib/builderSteps';
 import { logUx } from '@/lib/uxAnalytics';
+import { formatOptionValue, getDisplayPlacement } from '@/lib/product-display';
 
 const PRESET_SIZES = [
   { w: 48, h: 24 },
@@ -2385,13 +2386,10 @@ const GoogleAdsBanner: React.FC = () => {
                     secondaryLine={`for ${quantity} ${quantity === 1 ? 'banner' : 'banners'} • ${widthDisplay} × ${heightDisplay} • ${materialLabel}`}
                     showTopSummary={false}
                     detailRows={[
-                      { label: 'Grommets', value: grommetsLabel },
-                      ...(polePockets !== 'none'
-                        ? [{ label: `Pole Pockets (${polePockets})`, value: usd(bannerPricing.polePocketCostCents / 100) }]
-                        : []),
-                      ...(addRope
-                        ? [{ label: 'Rope', value: usd(bannerPricing.ropeCostCents / 100) }]
-                        : []),
+                      { label: 'Grommets', value: formatOptionValue(grommetsLabel) },
+                      { label: 'Pole Pockets', value: formatOptionValue(getDisplayPlacement(polePockets)) },
+                      { label: 'Rope Hemming', value: formatOptionValue(addRope ? getDisplayPlacement(ropePlacement) : '') },
+                      { label: 'Hemming', value: 'Always Included' },
                     ]}
                     baseSubtotalCents={bannerPricing.baseBannerPriceCents}
                     baseSubtotalLabel="Base banner"


### PR DESCRIPTION
### Motivation
- Ensure the product designer pricing summary visually matches the rest of the site by always showing all finishing option categories and using the same normalization logic used by checkout/cart/order/admin/email flows.
- Avoid hiding rows when values are null/undefined/false while keeping pricing calculations unchanged.

### Description
- Import and use the shared helpers `formatOptionValue` and `getDisplayPlacement` from `src/lib/product-display.ts` in `src/pages/GoogleAdsBanner.tsx` to normalize display values.
- Replace conditional `detailRows` rendering with a fixed set of rows so the designer always shows `Grommets`, `Pole Pockets`, `Rope Hemming`, and `Hemming`.
- Use `formatOptionValue(...)` for fallback behavior so unselected values render as `None`, and always render `Hemming` as `Always Included`.
- This is a display-only change and does not modify any pricing calculations or add-on cost logic.

### Testing
- Ran the linter command `npm run -s lint src/pages/GoogleAdsBanner.tsx`, which failed in this environment due to a missing local dependency (`@eslint/js`) unrelated to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd80d93008333a01cda1d20765e16)