### PR TITLE
Add Cloudflare R2 upload client and S3 SDK dependency

### DIFF
--- a/netlify/functions/lib/r2-client.cjs
+++ b/netlify/functions/lib/r2-client.cjs
@@ -1,0 +1,48 @@
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+
+let cachedClient = null;
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function getR2Client() {
+  if (cachedClient) return cachedClient;
+
+  const accountId = getRequiredEnv('R2_ACCOUNT_ID');
+  const accessKeyId = getRequiredEnv('R2_ACCESS_KEY_ID');
+  const secretAccessKey = getRequiredEnv('R2_SECRET_ACCESS_KEY');
+
+  cachedClient = new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+  });
+
+  return cachedClient;
+}
+
+async function uploadBufferToR2({ key, body, contentType, cacheControl = 'public, max-age=31536000, immutable' }) {
+  const bucket = getRequiredEnv('R2_BUCKET');
+  const publicBaseUrl = getRequiredEnv('R2_PUBLIC_BASE_URL');
+
+  const client = getR2Client();
+  await client.send(new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    Body: body,
+    ContentType: contentType,
+    CacheControl: cacheControl,
+  }));
+
+  return `${publicBaseUrl.replace(/\/$/, '')}/${key}`;
+}
+
+module.exports = {
+  getR2Client,
+  uploadBufferToR2,
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:studio": "netlify dev:exec drizzle-kit studio"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.864.0",
     "@google/genai": "^1.20.0",
     "@google/generative-ai": "^0.24.1",
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
### Motivation
- Provide a reusable server-side helper to upload buffers to Cloudflare R2 via an S3-compatible client for Netlify functions.

### Description
- Add `netlify/functions/lib/r2-client.cjs` which exports `getR2Client` and `uploadBufferToR2` and caches a single `S3Client` instance.
- Implement `uploadBufferToR2` to send `PutObjectCommand` uploads and return a public URL, and require environment variables `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, and `R2_PUBLIC_BASE_URL`.
- Configure the `S3Client` to use `endpoint` `https://${accountId}.r2.cloudflarestorage.com` with `region: 'auto'` and set a default `CacheControl` header.
- Add the `@aws-sdk/client-s3` dependency to `package.json`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c11233a588333a2022813a1f2f1b1)