### PR TITLE
Admin: Add per-order profit estimates using Brunck supplier cost rules

### DIFF
--- a/src/components/orders/OrderDetails.tsx
+++ b/src/components/orders/OrderDetails.tsx
@@ -1106,14 +1106,16 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order, trigger, onUploadFin
               <div className="mt-6 bg-gradient-to-br from-emerald-50 to-emerald-100 border-2 border-emerald-200 rounded-xl p-6 shadow-sm">
                 <h3 className="text-lg font-bold text-emerald-800 mb-4">Profit Estimate</h3>
                 {profit.needsReview ? (
-                  <div className="text-sm font-semibold text-amber-700">Needs review</div>
+                  <div className="inline-flex rounded bg-amber-100 px-2 py-1 text-sm font-semibold text-amber-800">Needs review</div>
                 ) : (
                   <div className="space-y-2 text-sm">
-                    <div className="flex justify-between"><span>Retail Subtotal</span><span className="font-semibold">{usd(profit.retailSubtotalCents / 100)}</span></div>
-                    <div className="flex justify-between"><span>Production Cost</span><span className="font-semibold">{usd(profit.productionCostCents / 100)}</span></div>
-                    <div className="flex justify-between"><span>Shipping/Handling Cost</span><span className="font-semibold">{usd(profit.shippingCostCents / 100)}</span></div>
-                    <div className="flex justify-between border-t pt-2"><span className="font-semibold">Estimated Net Profit</span><span className="font-bold">{usd(profit.netProfitCents / 100)}</span></div>
-                    <div className="flex justify-between"><span>Profit Margin %</span><span className="font-semibold">{profit.marginPct.toFixed(1)}%</span></div>
+                    <div className="flex justify-between"><span>Original Subtotal</span><span className="font-semibold">{usd(profit.originalSubtotalCents / 100)}</span></div>
+                    {profit.discountsAppliedCents > 0 && <div className="flex justify-between"><span>Discounts Applied</span><span className="font-semibold text-red-700">-{usd(profit.discountsAppliedCents / 100)}</span></div>}
+                    <div className="flex justify-between"><span>Adjusted Retail Subtotal (before tax)</span><span className="font-semibold">{usd(profit.adjustedRetailSubtotalCents / 100)}</span></div>
+                    <div className="flex justify-between text-slate-700"><span>Production Cost</span><span className="font-semibold">{usd(profit.productionCostCents / 100)}</span></div>
+                    <div className="flex justify-between text-slate-700"><span>Shipping/Handling Cost</span><span className="font-semibold">{usd(profit.shippingCostCents / 100)}</span></div>
+                    <div className="flex justify-between border-t pt-2"><span className="font-semibold">Estimated Net Profit</span><span className={`font-bold ${profit.netProfitCents >= 0 ? 'text-green-700' : 'text-red-700'}`}>{usd(profit.netProfitCents / 100)}</span></div>
+                    <div className="flex justify-between"><span>Profit Margin %</span><span className={`font-semibold ${profit.marginPct >= 0 ? 'text-green-700' : 'text-red-700'}`}>{profit.marginPct.toFixed(1)}%</span></div>
                   </div>
                 )}
               </div>

--- a/src/components/orders/OrderDetails.tsx
+++ b/src/components/orders/OrderDetails.tsx
@@ -11,6 +11,7 @@ import EmailDeliveryStatus from './EmailDeliveryStatus';
 import { getItemDisplayName, getProductLabel, normalizeOrderItemDisplay, type NormalizableOrderItem } from '@/lib/product-display';
 import { formatShippingAddress, hasShippingAddress, normalizeShippingAddress } from '@/lib/shipping-address';
 import { getDisplayOrderTotalCents } from '@/lib/order-totals';
+import { estimateOrderProfit } from '@/lib/admin-profit-estimate';
 import {
   Dialog,
   DialogContent,
@@ -1098,6 +1099,26 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order, trigger, onUploadFin
               </div>
             </div>
           </div>
+
+          {isAdminUser && (() => {
+            const profit = estimateOrderProfit(order);
+            return (
+              <div className="mt-6 bg-gradient-to-br from-emerald-50 to-emerald-100 border-2 border-emerald-200 rounded-xl p-6 shadow-sm">
+                <h3 className="text-lg font-bold text-emerald-800 mb-4">Profit Estimate</h3>
+                {profit.needsReview ? (
+                  <div className="text-sm font-semibold text-amber-700">Needs review</div>
+                ) : (
+                  <div className="space-y-2 text-sm">
+                    <div className="flex justify-between"><span>Retail Subtotal</span><span className="font-semibold">{usd(profit.retailSubtotalCents / 100)}</span></div>
+                    <div className="flex justify-between"><span>Production Cost</span><span className="font-semibold">{usd(profit.productionCostCents / 100)}</span></div>
+                    <div className="flex justify-between"><span>Shipping/Handling Cost</span><span className="font-semibold">{usd(profit.shippingCostCents / 100)}</span></div>
+                    <div className="flex justify-between border-t pt-2"><span className="font-semibold">Estimated Net Profit</span><span className="font-bold">{usd(profit.netProfitCents / 100)}</span></div>
+                    <div className="flex justify-between"><span>Profit Margin %</span><span className="font-semibold">{profit.marginPct.toFixed(1)}%</span></div>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/lib/admin-profit-estimate.ts
+++ b/src/lib/admin-profit-estimate.ts
@@ -103,6 +103,24 @@ const estimateLineItemCost = (item: OrderItem): LineEstimate => {
   return { reviewRequired: true, productionCostCents: 0, reason: `Unsupported product type: ${type}` };
 };
 
+const getRetailSubtotalBeforeTaxCents = (order: Order): number => {
+  const itemSubtotal = (order.items || []).reduce((sum, item) => {
+    const lineTotal = Number(item?.line_total_cents);
+    return sum + (Number.isFinite(lineTotal) ? lineTotal : 0);
+  }, 0);
+
+  const discount = Number.isFinite(Number(order.applied_discount_cents)) ? Number(order.applied_discount_cents) : 0;
+  const sameDay = Number.isFinite(Number(order.same_day_fee_cents)) ? Number(order.same_day_fee_cents) : 0;
+  const saturday = Number.isFinite(Number(order.saturday_fee_cents)) ? Number(order.saturday_fee_cents) : 0;
+
+  if (itemSubtotal > 0) {
+    return Math.max(0, itemSubtotal - discount + sameDay + saturday);
+  }
+
+  const storedSubtotal = Number.isFinite(Number(order.subtotal_cents)) ? Number(order.subtotal_cents) : 0;
+  return Math.max(0, storedSubtotal);
+};
+
 export const estimateOrderProfit = (order: Order) => {
   const lineEstimates = (order.items || []).map((item, idx) => {
     const estimate = estimateLineItemCost(item);
@@ -123,7 +141,7 @@ export const estimateOrderProfit = (order: Order) => {
 
   const needsReview = lineEstimates.some((x) => x.reviewRequired);
   const productionCostCents = lineEstimates.reduce((sum, x) => sum + x.productionCostCents, 0);
-  const retailSubtotalCents = order.subtotal_cents || 0;
+  const retailSubtotalCents = getRetailSubtotalBeforeTaxCents(order);
   const shippingCostCents = ADMIN_PROFIT_SHIPPING_COST_CENTS;
   const netProfitCents = retailSubtotalCents - productionCostCents - shippingCostCents;
   const marginPct = retailSubtotalCents > 0 ? (netProfitCents / retailSubtotalCents) * 100 : 0;

--- a/src/lib/admin-profit-estimate.ts
+++ b/src/lib/admin-profit-estimate.ts
@@ -1,0 +1,139 @@
+import type { Order, OrderItem } from './orders/types';
+
+export const ADMIN_PROFIT_SHIPPING_COST_CENTS = 1000;
+
+const bannerMaterialCostPerSqFt: Record<string, number> = {
+  '13oz': 1.25,
+  '15oz': 1.75,
+  '18oz': 2.25,
+  mesh: 2.44,
+};
+
+const magnetUnitCosts: Record<string, number> = {
+  '18x12': 11.95,
+  '24x12': 14.95,
+  '24x18': 20.95,
+  '42x12': 29.95,
+  '72x24': 89.7,
+};
+
+type LineEstimate = {
+  reviewRequired: boolean;
+  productionCostCents: number;
+  reason?: string;
+};
+
+const normalizeDimKey = (wIn?: number, hIn?: number): string | null => {
+  if (!Number.isFinite(wIn) || !Number.isFinite(hIn)) return null;
+  const dims = [Math.round(wIn || 0), Math.round(hIn || 0)].sort((a, b) => a - b);
+  return `${dims[0]}x${dims[1]}`;
+};
+
+const parsePolePocketEdges = (polePocketPosition?: string): string[] => {
+  if (!polePocketPosition) return [];
+  return polePocketPosition
+    .toLowerCase()
+    .split(/[|,+]/g)
+    .map((x) => x.trim())
+    .filter(Boolean);
+};
+
+const estimateBannerCost = (item: OrderItem): LineEstimate => {
+  if (!item.material || !Number.isFinite(item.width_in) || !Number.isFinite(item.height_in) || !Number.isFinite(item.quantity)) {
+    return { reviewRequired: true, productionCostCents: 0, reason: 'Missing banner fields' };
+  }
+
+  const materialRate = bannerMaterialCostPerSqFt[item.material];
+  if (!materialRate) {
+    return { reviewRequired: true, productionCostCents: 0, reason: `Unknown banner material: ${item.material}` };
+  }
+
+  const squareFeetPerBanner = (item.width_in / 12) * (item.height_in / 12);
+  const qty = item.quantity || 0;
+  let totalCost = squareFeetPerBanner * materialRate * qty;
+
+  const edges = parsePolePocketEdges(item.pole_pocket_position || item.pole_pockets);
+  if (edges.length > 0) {
+    let linearFeet = 0;
+    for (const edge of edges) {
+      if (edge.includes('top') || edge.includes('bottom')) linearFeet += item.width_in / 12;
+      if (edge.includes('left') || edge.includes('right')) linearFeet += item.height_in / 12;
+    }
+    totalCost += linearFeet * 1.0 * qty;
+    totalCost += 10; // setup fee once per line when selected
+  }
+
+  if (Number.isFinite(item.rope_feet) && (item.rope_feet || 0) > 0) {
+    totalCost += (item.rope_feet || 0) * 1.0;
+  }
+
+  return { reviewRequired: false, productionCostCents: Math.round(totalCost * 100) };
+};
+
+const estimateMagnetCost = (item: OrderItem): LineEstimate => {
+  const key = normalizeDimKey(item.width_in, item.height_in);
+  if (!key || !Number.isFinite(item.quantity)) {
+    return { reviewRequired: true, productionCostCents: 0, reason: 'Missing magnet dimensions/quantity' };
+  }
+  const unit = magnetUnitCosts[key];
+  if (!unit) return { reviewRequired: true, productionCostCents: 0, reason: `Unknown magnet size: ${key}` };
+  return { reviewRequired: false, productionCostCents: Math.round(unit * item.quantity * 100) };
+};
+
+const estimateYardSignCost = (item: OrderItem): LineEstimate => {
+  if (!Number.isFinite(item.quantity)) return { reviewRequired: true, productionCostCents: 0, reason: 'Missing yard sign quantity' };
+  const qty = item.quantity || 0;
+  if (qty % 10 !== 0) return { reviewRequired: true, productionCostCents: 0, reason: `Yard sign qty not divisible by 10: ${qty}` };
+
+  const doubleSided = [item.grommets, item.pole_pockets, item.pole_pocket_position]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+    .includes('double');
+
+  const unit = doubleSided ? 5.5 : 4.4;
+  return { reviewRequired: false, productionCostCents: Math.round(unit * qty * 100) };
+};
+
+const estimateLineItemCost = (item: OrderItem): LineEstimate => {
+  const type = (item.product_type || 'banner').toLowerCase();
+  if (type.includes('magnet')) return estimateMagnetCost(item);
+  if (type.includes('yard_sign') || type.includes('yardsign') || type.includes('yard-sign')) return estimateYardSignCost(item);
+  if (type === 'banner' || type.includes('banner')) return estimateBannerCost(item);
+  return { reviewRequired: true, productionCostCents: 0, reason: `Unsupported product type: ${type}` };
+};
+
+export const estimateOrderProfit = (order: Order) => {
+  const lineEstimates = (order.items || []).map((item, idx) => {
+    const estimate = estimateLineItemCost(item);
+    if (estimate.reviewRequired) {
+      console.warn('[admin-profit] Needs review line item', {
+        orderId: order.id,
+        index: idx,
+        productType: item.product_type,
+        material: item.material,
+        widthIn: item.width_in,
+        heightIn: item.height_in,
+        quantity: item.quantity,
+        reason: estimate.reason,
+      });
+    }
+    return estimate;
+  });
+
+  const needsReview = lineEstimates.some((x) => x.reviewRequired);
+  const productionCostCents = lineEstimates.reduce((sum, x) => sum + x.productionCostCents, 0);
+  const retailSubtotalCents = order.subtotal_cents || 0;
+  const shippingCostCents = ADMIN_PROFIT_SHIPPING_COST_CENTS;
+  const netProfitCents = retailSubtotalCents - productionCostCents - shippingCostCents;
+  const marginPct = retailSubtotalCents > 0 ? (netProfitCents / retailSubtotalCents) * 100 : 0;
+
+  return {
+    needsReview,
+    retailSubtotalCents,
+    productionCostCents,
+    shippingCostCents,
+    netProfitCents,
+    marginPct,
+  };
+};

--- a/src/lib/admin-profit-estimate.ts
+++ b/src/lib/admin-profit-estimate.ts
@@ -103,7 +103,7 @@ const estimateLineItemCost = (item: OrderItem): LineEstimate => {
   return { reviewRequired: true, productionCostCents: 0, reason: `Unsupported product type: ${type}` };
 };
 
-const getRetailSubtotalBeforeTaxCents = (order: Order): number => {
+const getRevenueBreakdownCents = (order: Order) => {
   const itemSubtotal = (order.items || []).reduce((sum, item) => {
     const lineTotal = Number(item?.line_total_cents);
     return sum + (Number.isFinite(lineTotal) ? lineTotal : 0);
@@ -114,11 +114,21 @@ const getRetailSubtotalBeforeTaxCents = (order: Order): number => {
   const saturday = Number.isFinite(Number(order.saturday_fee_cents)) ? Number(order.saturday_fee_cents) : 0;
 
   if (itemSubtotal > 0) {
-    return Math.max(0, itemSubtotal - discount + sameDay + saturday);
+    const originalSubtotalCents = Math.max(0, itemSubtotal + sameDay + saturday);
+    const adjustedRetailSubtotalCents = Math.max(0, itemSubtotal - discount + sameDay + saturday);
+    return {
+      originalSubtotalCents,
+      discountsAppliedCents: Math.max(0, discount),
+      adjustedRetailSubtotalCents,
+    };
   }
 
   const storedSubtotal = Number.isFinite(Number(order.subtotal_cents)) ? Number(order.subtotal_cents) : 0;
-  return Math.max(0, storedSubtotal);
+  return {
+    originalSubtotalCents: Math.max(0, storedSubtotal + discount),
+    discountsAppliedCents: Math.max(0, discount),
+    adjustedRetailSubtotalCents: Math.max(0, storedSubtotal),
+  };
 };
 
 export const estimateOrderProfit = (order: Order) => {
@@ -141,13 +151,17 @@ export const estimateOrderProfit = (order: Order) => {
 
   const needsReview = lineEstimates.some((x) => x.reviewRequired);
   const productionCostCents = lineEstimates.reduce((sum, x) => sum + x.productionCostCents, 0);
-  const retailSubtotalCents = getRetailSubtotalBeforeTaxCents(order);
+  const revenue = getRevenueBreakdownCents(order);
+  const retailSubtotalCents = revenue.adjustedRetailSubtotalCents;
   const shippingCostCents = ADMIN_PROFIT_SHIPPING_COST_CENTS;
   const netProfitCents = retailSubtotalCents - productionCostCents - shippingCostCents;
   const marginPct = retailSubtotalCents > 0 ? (netProfitCents / retailSubtotalCents) * 100 : 0;
 
   return {
     needsReview,
+    originalSubtotalCents: revenue.originalSubtotalCents,
+    discountsAppliedCents: revenue.discountsAppliedCents,
+    adjustedRetailSubtotalCents: revenue.adjustedRetailSubtotalCents,
     retailSubtotalCents,
     productionCostCents,
     shippingCostCents,

--- a/src/pages/admin/Orders.tsx
+++ b/src/pages/admin/Orders.tsx
@@ -1417,12 +1417,16 @@ const AdminOrderRow: React.FC<AdminOrderRowProps> = ({
             return (
               <div className="rounded-md border border-slate-200 bg-slate-50 p-2 text-xs"> 
                 {profit.needsReview ? (
-                  <div className="font-semibold text-amber-700">Profit: Needs review</div>
+                  <div className="inline-flex rounded bg-amber-100 px-2 py-1 font-semibold text-amber-800">Needs review</div>
                 ) : (
                   <>
-                    <div className="text-slate-700">Cost: <span className="font-semibold">{usd(profit.productionCostCents / 100)}</span></div>
-                    <div className="text-slate-700">Profit: <span className="font-semibold">{usd(profit.netProfitCents / 100)}</span></div>
-                    <div className="text-slate-700">Margin: <span className="font-semibold">{profit.marginPct.toFixed(1)}%</span></div>
+                    <div className="text-slate-700">Revenue: <span className="font-semibold">{usd(profit.originalSubtotalCents / 100)}</span></div>
+                    {profit.discountsAppliedCents > 0 && <div className="text-slate-700">Discounts: <span className="font-semibold text-red-700">-{usd(profit.discountsAppliedCents / 100)}</span></div>}
+                    <div className="text-slate-700">Adjusted Subtotal: <span className="font-semibold">{usd(profit.adjustedRetailSubtotalCents / 100)}</span></div>
+                    <div className="text-gray-600">Production Cost: <span className="font-semibold">{usd(profit.productionCostCents / 100)}</span></div>
+                    <div className="text-gray-600">Shipping Cost: <span className="font-semibold">{usd(profit.shippingCostCents / 100)}</span></div>
+                    <div className="text-slate-700">Net Profit: <span className={`font-semibold ${profit.netProfitCents >= 0 ? 'text-green-700' : 'text-red-700'}`}>{usd(profit.netProfitCents / 100)}</span></div>
+                    <div className="text-slate-700">Margin: <span className={`font-semibold ${profit.marginPct >= 0 ? 'text-green-700' : 'text-red-700'}`}>{profit.marginPct.toFixed(1)}%</span></div>
                   </>
                 )}
               </div>
@@ -1873,7 +1877,7 @@ const AdminOrderCard: React.FC<AdminOrderCardProps> = ({
             <div>
               <div className="text-xs text-gray-500">Total</div>
               <div className="text-lg font-bold text-[#18448D]">{usd(getDisplayOrderTotalCents(order as any) / 100)}</div>
-            {(() => { const profit = estimateOrderProfit(order); return profit.needsReview ? (<div className="text-xs font-semibold text-amber-700">Profit: Needs review</div>) : (<div className="text-xs text-slate-700">Cost {usd(profit.productionCostCents/100)} · Profit {usd(profit.netProfitCents/100)} · Margin {profit.marginPct.toFixed(1)}%</div>); })()}
+            {(() => { const profit = estimateOrderProfit(order); return profit.needsReview ? (<div className="inline-flex rounded bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-800">Needs review</div>) : (<div className="text-xs text-slate-700">Rev {usd(profit.originalSubtotalCents/100)}{profit.discountsAppliedCents>0 ? ` · Disc -${usd(profit.discountsAppliedCents/100)}` : ''} · Adj {usd(profit.adjustedRetailSubtotalCents/100)} · Cost {usd(profit.productionCostCents/100)} · Ship {usd(profit.shippingCostCents/100)} · <span className={`${profit.netProfitCents>=0?'text-green-700':'text-red-700'} font-semibold`}>Profit {usd(profit.netProfitCents/100)}</span> · <span className={`${profit.marginPct>=0?'text-green-700':'text-red-700'} font-semibold`}>Margin {profit.marginPct.toFixed(1)}%</span></div>); })()}
             </div>
             {!isGraduation && order.tracking_number && (
               <div className="min-w-0">

--- a/src/pages/admin/Orders.tsx
+++ b/src/pages/admin/Orders.tsx
@@ -33,6 +33,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Calendar as CalendarIcon, Star, ShoppingCart, GraduationCap } from 'lucide-react';
 import OrderDetails from '@/components/orders/OrderDetails';
 import { getDisplayOrderTotalCents } from '@/lib/order-totals';
+import { estimateOrderProfit } from '@/lib/admin-profit-estimate';
 import { fetchEvents } from '@/lib/events';
 import {
   Select,
@@ -1411,6 +1412,22 @@ const AdminOrderRow: React.FC<AdminOrderRowProps> = ({
             <div className="text-sm text-gray-900">{getItemsSummary(order)}</div>
           </div>
           <div className={`text-lg font-bold ${ORDER_ACCENT_TEXT_CLASS}`}>{usd(getDisplayOrderTotalCents(order as any) / 100)}</div>
+          {(() => {
+            const profit = estimateOrderProfit(order);
+            return (
+              <div className="rounded-md border border-slate-200 bg-slate-50 p-2 text-xs"> 
+                {profit.needsReview ? (
+                  <div className="font-semibold text-amber-700">Profit: Needs review</div>
+                ) : (
+                  <>
+                    <div className="text-slate-700">Cost: <span className="font-semibold">{usd(profit.productionCostCents / 100)}</span></div>
+                    <div className="text-slate-700">Profit: <span className="font-semibold">{usd(profit.netProfitCents / 100)}</span></div>
+                    <div className="text-slate-700">Margin: <span className="font-semibold">{profit.marginPct.toFixed(1)}%</span></div>
+                  </>
+                )}
+              </div>
+            );
+          })()}
           <div className="flex flex-wrap gap-1.5">
             <Badge className={`${getStatusColor(order.status)} capitalize`}>
               {getStatusLabel(order.status)}
@@ -1856,6 +1873,7 @@ const AdminOrderCard: React.FC<AdminOrderCardProps> = ({
             <div>
               <div className="text-xs text-gray-500">Total</div>
               <div className="text-lg font-bold text-[#18448D]">{usd(getDisplayOrderTotalCents(order as any) / 100)}</div>
+            {(() => { const profit = estimateOrderProfit(order); return profit.needsReview ? (<div className="text-xs font-semibold text-amber-700">Profit: Needs review</div>) : (<div className="text-xs text-slate-700">Cost {usd(profit.productionCostCents/100)} · Profit {usd(profit.netProfitCents/100)} · Margin {profit.marginPct.toFixed(1)}%</div>); })()}
             </div>
             {!isGraduation && order.tracking_number && (
               <div className="min-w-0">


### PR DESCRIPTION
### Motivation
- Provide admin-only visibility into estimated net profit per order using Brunck Print Services supplier cost rules without changing any customer-facing pricing, checkout, cart, tax, email, or payment logic.  
- Centralize profit calculation logic so it can be reused by the admin list, order detail view, and future analytics dashboards.

### Description
- Added a centralized estimator `estimateOrderProfit` in `src/lib/admin-profit-estimate.ts` that returns retail subtotal, production cost, one-time $10 shipping/handling cost, estimated net profit, margin percent, and a `needsReview` flag.  
- Implemented supplier cost rules: banner material cost per sq ft, banner area calculation (`width_in * height_in / 144`), pole-pocket linear-foot + $10 setup fee (edge-aware), rope linear-foot cost, magnet fixed unit costs by size, yard sign single/double-sided unit costs and quantity divisibility validation, and a $10/order shipping cost for admin reporting.  
- Integrated the estimator into the admin list UI (`src/pages/admin/Orders.tsx`) for desktop rows and mobile cards and added a dedicated `Profit Estimate` section to the admin order detail modal (`src/components/orders/OrderDetails.tsx`) that displays Retail Subtotal, Production Cost, Shipping/Handling Cost, Estimated Net Profit, Profit Margin %, or a `Needs review` fallback.  
- Added defensive behavior and logging: any unknown/missing product data or unsupported types produce `Needs review` (no UI-breaking errors) and a console warning with enough context for internal debugging.

### Testing
- Attempted an automated build with `npm run -s build`, which failed in this environment because `vite` is not available (`sh: 1: vite: not found`). No other automated tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf6aa529c8333af3e6af9e37e4b88)