### PR TITLE
Improve visibility of yard sign minimum-order requirement

### DIFF
--- a/src/components/design/YardSignConfigurator.tsx
+++ b/src/components/design/YardSignConfigurator.tsx
@@ -504,9 +504,19 @@ const YardSignConfigurator: React.FC<YardSignConfiguratorProps> = ({
         <p className="text-xs text-gray-500 mb-2">
           Upload up to {YARD_SIGN_MAX_DESIGNS} designs. Each will be printed at 24&quot; × 18&quot;. Assign a quantity to each design.
         </p>
-        <p className="text-xs text-gray-500 font-medium mb-3">
-          Minimum order is {YARD_SIGN_MIN_QUANTITY} signs. Total must be in increments of {YARD_SIGN_INCREMENT}.
-        </p>
+        <div className="mt-4 mb-4 rounded-xl border border-amber-200/80 bg-amber-50/60 px-3.5 py-3 sm:px-4 sm:py-3.5">
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" aria-hidden="true" />
+            <div className="border-l-2 border-amber-400/90 pl-3">
+              <p className="text-sm sm:text-base font-bold text-amber-900 leading-snug">
+                Minimum order: {YARD_SIGN_MIN_QUANTITY} signs
+              </p>
+              <p className="mt-1 text-sm sm:text-[0.95rem] font-semibold text-amber-800 leading-snug">
+                Quantities must be ordered in increments of {YARD_SIGN_INCREMENT}.
+              </p>
+            </div>
+          </div>
+        </div>
 
         {/* Design rows */}
         {designs.length > 0 && (

--- a/src/components/design/YardSignConfigurator.tsx
+++ b/src/components/design/YardSignConfigurator.tsx
@@ -508,10 +508,10 @@ const YardSignConfigurator: React.FC<YardSignConfiguratorProps> = ({
           <div className="flex items-start gap-2.5">
             <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" aria-hidden="true" />
             <div className="border-l-2 border-amber-400/90 pl-3">
-              <p className="text-sm sm:text-base font-bold text-amber-900 leading-snug">
+              <p className="text-base sm:text-lg font-extrabold text-amber-900 leading-tight tracking-tight">
                 Minimum order: {YARD_SIGN_MIN_QUANTITY} signs
               </p>
-              <p className="mt-1 text-sm sm:text-[0.95rem] font-semibold text-amber-800 leading-snug">
+              <p className="mt-1 text-sm sm:text-[0.95rem] font-medium text-amber-800/95 leading-snug">
                 Quantities must be ordered in increments of {YARD_SIGN_INCREMENT}.
               </p>
             </div>


### PR DESCRIPTION
### Motivation
- The existing minimum-order helper line in the Yard Signs "Add Designs" step was easy to miss under the upload section and needed to be much more visually prominent without changing behavior or branding. 
- The change aims to make the 10-sign minimum and 10-sign increment requirement obvious at a glance while retaining a clean, professional look and strong mobile responsiveness.

### Description
- Replaced the small helper paragraph with a prominent, responsive callout block in `src/components/design/YardSignConfigurator.tsx` that includes a subtle highlighted background, left-accent border, and an info-style icon. 
- Updated copy to the requested text: `Minimum order: 10 signs` and `Quantities must be ordered in increments of 10.`
- Increased emphasis via larger/bolder type, stronger contrast, and added spacing above the block to separate it from the preceding paragraph, while keeping responsive classes (`text-sm` → `sm:text-base` where appropriate). 
- No functional logic was changed; upload behavior, quantity validation, and step flow remain unchanged.

### Testing
- Ran the project lint command (`npm run -s lint`), which failed to run in this environment due to a missing ESLint dependency (`@eslint/js`).
- No other automated tests were modified or executed as part of this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d004e8aa483338bc3e656bddccbb9)