### PR TITLE
Hide banner-only finishing rows for Yard Signs in customer-facing summaries

### DIFF
--- a/netlify/functions/email-template.cjs
+++ b/netlify/functions/email-template.cjs
@@ -129,9 +129,10 @@ function renderItems(items = []) {
                     <p style="margin:0 0 4px;color:#475569;font-size:13px;">Qty: ${quantity}</p>
                     ${item.uploadedDesignsCount ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Uploaded Designs: ${Number(item.uploadedDesignsCount)}</p>` : ''}
                     ${item.stepStakesQty ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Step Stakes: ${Number(item.stepStakesQty)}</p>` : ''}
-                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Grommets: ${escapeHtml(item.grommetsDisplay || 'None')}</p>
+                    ${(!isYardSign && !isCarMagnet) ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Grommets: ${escapeHtml(item.grommetsDisplay || 'None')}</p>
                     <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Pole Pockets: ${escapeHtml(item.polePocketsDisplay || 'None')}</p>
-                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rope: ${escapeHtml(item.ropeDisplay || 'None')}</p><p style="margin:0 0 2px;color:#64748b;font-size:12px;">Hemming: Always included</p>
+                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rope: ${escapeHtml(item.ropeDisplay || 'None')}</p>
+                    <p style="margin:0 0 2px;color:#64748b;font-size:12px;">Hemming: Always included</p>` : ''}
                     ${item.roundedCornersDisplay ? `<p style="margin:0 0 2px;color:#64748b;font-size:12px;">Rounded Corners: ${escapeHtml(item.roundedCornersDisplay)}</p>` : ''}
                     ${lineTotal > 0 ? `<p style="margin:0 0 2px;color:${BRAND_NAVY};font-size:13px;font-weight:600;">Unit Price: $${unitPrice.toFixed(2)}</p>` : ''}
                     ${lineTotal > 0 ? `<p style="margin:0;color:${BRAND_ORANGE};font-size:14px;font-weight:700;">Line Total: $${lineTotal.toFixed(2)}</p>` : ''}

--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -184,10 +184,12 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                             { label: 'Qty', value: normalized.qtyDisplay },
                             ...(normalized.uploadedDesignsCount ? [{ label: 'Uploaded Designs', value: String(normalized.uploadedDesignsCount) }] : []),
                             ...(normalized.stepStakesQty ? [{ label: 'Step Stakes', value: String(normalized.stepStakesQty) }] : []),
-                            { label: 'Grommets', value: normalized.grommetsDisplay },
-                            { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
-                            { label: 'Rope', value: normalized.ropeDisplay },
-                            { label: 'Hemming', value: normalized.hemmingDisplay || 'Always included' },
+                            ...(normalized.productType === 'banner' ? [
+                              { label: 'Grommets', value: normalized.grommetsDisplay },
+                              { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
+                              { label: 'Rope', value: normalized.ropeDisplay },
+                              { label: 'Hemming', value: normalized.hemmingDisplay || 'Always included' },
+                            ] : []),
                             ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                           ]}
                           renderLargePreview={() => (
@@ -257,9 +259,13 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                         <p><span className="font-medium text-gray-700">Qty:</span> {normalized.qtyDisplay}</p>
                         {normalized.uploadedDesignsCount ? <p><span className="font-medium text-gray-700">Uploaded Designs:</span> {normalized.uploadedDesignsCount}</p> : null}
                         {normalized.stepStakesQty ? <p><span className="font-medium text-gray-700">Step Stakes:</span> {normalized.stepStakesQty}</p> : null}
-                        <p><span className="font-medium text-gray-700">Grommets:</span> {normalized.grommetsDisplay}</p>
-                        <p><span className="font-medium text-gray-700">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
-                        <p><span className="font-medium text-gray-700">Rope:</span> {normalized.ropeDisplay}</p>
+                        {normalized.productType === 'banner' ? (
+                          <>
+                            <p><span className="font-medium text-gray-700">Grommets:</span> {normalized.grommetsDisplay}</p>
+                            <p><span className="font-medium text-gray-700">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
+                            <p><span className="font-medium text-gray-700">Rope:</span> {normalized.ropeDisplay}</p>
+                          </>
+                        ) : null}
                         {normalized.roundedCornersDisplay ? <p><span className="font-medium text-gray-700">Rounded Corners:</span> {normalized.roundedCornersDisplay}</p> : null}
                       </div>
 

--- a/src/components/orders/OrderDetails.tsx
+++ b/src/components/orders/OrderDetails.tsx
@@ -933,9 +933,13 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order, trigger, onUploadFin
                       <p className="break-words">Qty: {normalized.qtyDisplay}</p>
                       {normalized.uploadedDesignsCount ? <p className="break-words">Uploaded Designs: {normalized.uploadedDesignsCount}</p> : null}
                       {normalized.stepStakesQty ? <p className="break-words">Step Stakes: {normalized.stepStakesQty}</p> : null}
-                      <p className="break-words">Grommets: {normalized.grommetsDisplay}</p>
-                      <p className="break-words">Pole Pockets: {normalized.polePocketsDisplay}</p>
-                      <p className="break-words">Rope: {normalized.ropeDisplay}</p>
+                      {normalized.productType === 'banner' ? (
+                        <>
+                          <p className="break-words">Grommets: {normalized.grommetsDisplay}</p>
+                          <p className="break-words">Pole Pockets: {normalized.polePocketsDisplay}</p>
+                          <p className="break-words">Rope: {normalized.ropeDisplay}</p>
+                        </>
+                      ) : null}
                       {normalized.roundedCornersDisplay ? <p className="break-words">Rounded Corners: {normalized.roundedCornersDisplay}</p> : null}
                     </div>
 

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -628,10 +628,12 @@ const Checkout: React.FC = () => {
                       { label: 'Print', value: normalized.printDisplay },
                       ...(normalized.uploadedDesignsCount ? [{ label: 'Uploaded Designs', value: String(normalized.uploadedDesignsCount) }] : []),
                       ...(normalized.stepStakesQty ? [{ label: 'Step Stakes', value: String(normalized.stepStakesQty) }] : []),
-                      { label: 'Grommets', value: normalized.grommetsDisplay },
-                      { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
-                      { label: 'Rope', value: normalized.ropeDisplay },
-                      { label: 'Hemming', value: normalized.hemmingDisplay || 'Always included' },
+                      ...(normalized.productType === 'banner' ? [
+                        { label: 'Grommets', value: normalized.grommetsDisplay },
+                        { label: 'Pole Pockets', value: normalized.polePocketsDisplay },
+                        { label: 'Rope', value: normalized.ropeDisplay },
+                        { label: 'Hemming', value: normalized.hemmingDisplay || 'Always included' },
+                      ] : []),
                       ...(normalized.roundedCornersDisplay ? [{ label: 'Rounded Corners', value: normalized.roundedCornersDisplay }] : []),
                     ];
 

--- a/src/pages/OrderConfirmation.tsx
+++ b/src/pages/OrderConfirmation.tsx
@@ -194,9 +194,13 @@ const OrderConfirmation: React.FC = () => {
                           <p>Qty: {normalized.qtyDisplay}</p>
                           {normalized.uploadedDesignsCount && <p>Uploaded Designs: {normalized.uploadedDesignsCount}</p>}
                           {normalized.stepStakesQty && <p>Step Stakes: {normalized.stepStakesQty}</p>}
-                          <p>Grommets: {normalized.grommetsDisplay}</p>
-                          <p>Pole Pockets: {normalized.polePocketsDisplay}</p>
-                          <p>Rope: {normalized.ropeDisplay}</p>
+                          {normalized.productType === 'banner' ? (
+                            <>
+                              <p>Grommets: {normalized.grommetsDisplay}</p>
+                              <p>Pole Pockets: {normalized.polePocketsDisplay}</p>
+                              <p>Rope: {normalized.ropeDisplay}</p>
+                            </>
+                          ) : null}
                           {normalized.roundedCornersDisplay && <p>Rounded Corners: {normalized.roundedCornersDisplay}</p>}
                         </div>
 

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -302,9 +302,13 @@ const OrderDetail: React.FC = () => {
                         {normalized.stepStakesQty && (
                           <p><span className="font-medium">Step Stakes:</span> {normalized.stepStakesQty}</p>
                         )}
-                        <p><span className="font-medium">Grommets:</span> {normalized.grommetsDisplay}</p>
-                        <p><span className="font-medium">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
-                        <p><span className="font-medium">Rope:</span> {normalized.ropeDisplay}</p>
+                        {normalized.productType === 'banner' ? (
+                          <>
+                            <p><span className="font-medium">Grommets:</span> {normalized.grommetsDisplay}</p>
+                            <p><span className="font-medium">Pole Pockets:</span> {normalized.polePocketsDisplay}</p>
+                            <p><span className="font-medium">Rope:</span> {normalized.ropeDisplay}</p>
+                          </>
+                        ) : null}
                         {normalized.roundedCornersDisplay && (
                           <p><span className="font-medium">Rounded Corners:</span> {normalized.roundedCornersDisplay}</p>
                         )}

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -259,9 +259,13 @@ const PaymentSuccess: React.FC = () => {
                           </p>
                           {normalized.uploadedDesignsCount ? <p className="text-sm text-gray-600">Uploaded Designs: {normalized.uploadedDesignsCount}</p> : null}
                           {normalized.stepStakesQty ? <p className="text-sm text-gray-600">Step Stakes: {normalized.stepStakesQty}</p> : null}
-                          <p className="text-sm text-gray-600">Grommets: {normalized.grommetsDisplay}</p>
-                          <p className="text-sm text-gray-600">Pole Pockets: {normalized.polePocketsDisplay}</p>
-                          <p className="text-sm text-gray-600">Rope: {normalized.ropeDisplay}</p>
+                          {normalized.productType === 'banner' ? (
+                            <>
+                              <p className="text-sm text-gray-600">Grommets: {normalized.grommetsDisplay}</p>
+                              <p className="text-sm text-gray-600">Pole Pockets: {normalized.polePocketsDisplay}</p>
+                              <p className="text-sm text-gray-600">Rope: {normalized.ropeDisplay}</p>
+                            </>
+                          ) : null}
 
                           {/* Cost Breakdown */}
                           <div className="mt-3 p-3 bg-gray-50 rounded-lg">


### PR DESCRIPTION
### Motivation
- Yard Sign items were showing banner-only finishing rows (Grommets, Pole Pockets, Rope, Hemming) which do not apply to yard signs and created misleading/empty UI rows. 
- The goal is to remove those rows entirely for Yard Signs across all customer-facing summaries while keeping banner behavior unchanged. 
- Visibility decisions must be product-type-aware and reuse centralized display normalization where possible to ensure consistent behavior across views.

### Description
- Added product-type conditional rendering (`normalized.productType === 'banner'`) to the cart modal, checkout item preview, order detail, order confirmation, payment success, and order detail pages so Grommets/Pole Pockets/Rope/Hemming rows are only rendered for banners. 
- Updated the confirmation email template to inject finishing rows only when the item is not a yard sign or car magnet (`!isYardSign && !isCarMagnet`), preventing “None” placeholders for yard signs. 
- Changes rely on the existing `normalizeOrderItemDisplay` output (`normalized.productType`) and do not alter banner finishing rendering, pricing, quantity, upload, admin views, or print file generation. 
- Files modified: `src/components/CartModal.tsx`, `src/pages/Checkout.tsx`, `src/components/orders/OrderDetails.tsx`, `src/pages/OrderConfirmation.tsx`, `src/pages/PaymentSuccess.tsx`, `src/pages/OrderDetail.tsx`, and `netlify/functions/email-template.cjs`.

### Testing
- Ran `npm run -s typecheck` which failed because no `typecheck` script is defined in `package.json` in this environment. 
- Ran `npm run -s lint` which failed due to an environment dependency error importing `@eslint/js`, so ESLint could not complete in this environment. 
- No automated unit tests were executed in this environment; changes were implemented using centralized `normalized` display data to minimize risk and preserve banner behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d09523de48333b6b533187b9d1b71)