### PR TITLE
Add Independence Day shipping notice to product pages

### DIFF
--- a/src/components/IndependenceDayNotice.tsx
+++ b/src/components/IndependenceDayNotice.tsx
@@ -1,0 +1,36 @@
+import { Flag, Sparkles } from 'lucide-react';
+
+export const INDEPENDENCE_DAY_NOTICE =
+  'Independence Day schedule: Orders placed July 2–5 will ship Monday, July 6, for delivery Tuesday, July 7.';
+
+interface IndependenceDayNoticeProps {
+  className?: string;
+}
+
+const IndependenceDayNotice = ({ className = '' }: IndependenceDayNoticeProps) => {
+  return (
+    <aside
+      className={`relative overflow-hidden rounded-2xl border border-[#18448D]/20 bg-white shadow-sm ${className}`}
+      aria-label="Independence Day shipping schedule notice"
+    >
+      <div className="absolute inset-y-0 left-0 w-1.5 bg-gradient-to-b from-[#B91C1C] via-white to-[#18448D]" aria-hidden="true" />
+      <div className="absolute -right-8 -top-10 h-24 w-24 rounded-full bg-[#18448D]/10 blur-2xl" aria-hidden="true" />
+      <div className="absolute right-6 top-4 hidden text-[#B91C1C]/15 sm:block" aria-hidden="true">
+        <Sparkles className="h-10 w-10" />
+      </div>
+      <div className="flex flex-col gap-3 px-5 py-4 pl-7 sm:flex-row sm:items-center sm:gap-4 sm:px-6 sm:py-5 sm:pl-8">
+        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-[#18448D] text-white shadow-sm ring-4 ring-[#18448D]/10">
+          <Flag className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#B91C1C]">Holiday shipping notice</p>
+          <p className="text-sm font-semibold leading-6 text-[#0B1F3A] sm:text-base">
+            {INDEPENDENCE_DAY_NOTICE}
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default IndependenceDayNotice;

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { useParams, Link, Navigate } from 'react-router-dom';
 import Layout from '@/components/Layout';
+import IndependenceDayNotice from '@/components/IndependenceDayNotice';
 import SEO, {
   getBreadcrumbSchema,
   getProductSchema,
@@ -68,6 +69,10 @@ const CategoryPage: React.FC = () => {
           title={category.h1}
           subtitle={category.description}
         />
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+          <IndependenceDayNotice />
+        </div>
 
         {/* Main Content */}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/src/pages/CityProductPage.tsx
+++ b/src/pages/CityProductPage.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { useParams, Navigate, Link } from 'react-router-dom';
 import Layout from '@/components/Layout';
+import IndependenceDayNotice from '@/components/IndependenceDayNotice';
 import SEO, {
   getBreadcrumbSchema,
   getProductSchema,
@@ -111,6 +112,10 @@ const CityProductPage: React.FC<CityProductPageProps> = ({ productSlug }) => {
 
       <div className="bg-white">
         <PageHeader title={content.h1} subtitle={content.heroSubtitle} />
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+          <IndependenceDayNotice />
+        </div>
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-12">
           <Breadcrumbs items={content.breadcrumbs} />

--- a/src/pages/Design.tsx
+++ b/src/pages/Design.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams, useLocation, Link } from 'react-router-do
 import { Helmet } from 'react-helmet-async';
 import { Clock, Star, CheckCircle, Truck, X, Loader2, ArrowRight, Brush, Minus, Plus, Lock, Mail, Droplets, Sun, Wind, Palette, Tag, Move, ZoomIn, ZoomOut, Ruler, Layers, Sparkles } from 'lucide-react';
 import Layout from '@/components/Layout';
+import IndependenceDayNotice from '@/components/IndependenceDayNotice';
 import { useQuoteStore, type MaterialKey } from '@/store/quote';
 import { useCartStore, type CartItem } from '@/store/cart';
 import { useUIStore } from '@/store/ui';
@@ -2050,6 +2051,12 @@ const Design: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <div className="bg-gray-50 px-4 pt-6">
+        <div className="mx-auto max-w-4xl lg:max-w-7xl">
+          <IndependenceDayNotice />
+        </div>
+      </div>
 
       <section ref={orderRef} id="order-builder" className="py-12 px-4 bg-gray-50">
         <div className="max-w-4xl lg:max-w-7xl mx-auto">

--- a/src/pages/GoogleAdsBanner.tsx
+++ b/src/pages/GoogleAdsBanner.tsx
@@ -12,6 +12,7 @@ import { resolvePromo } from '@/lib/promoEngine';
 import { DESIGN_GROMMET_OPTIONS } from '@/lib/grommets';
 import UpsellModal, { UpsellOption } from '@/components/cart/UpsellModal';
 import CartModal from '@/components/CartModal';
+import IndependenceDayNotice from '@/components/IndependenceDayNotice';
 
 import { getQuantityDiscountRate } from '@/lib/quantity-discount';
 import { generateFinalRenderFromHTML } from '@/utils/generateFinalRenderFromHTML';
@@ -1850,6 +1851,12 @@ const GoogleAdsBanner: React.FC = () => {
             </div>
           </div>
         </section>
+
+        <div className="bg-gray-50 px-4 pt-6">
+          <div className="mx-auto max-w-4xl lg:max-w-7xl">
+            <IndependenceDayNotice />
+          </div>
+        </div>
 
         <section ref={orderRef} id="order-builder" className="mt-8 py-12 px-4 bg-gray-50">
           <div className="max-w-4xl lg:max-w-7xl mx-auto">

--- a/src/pages/GraduationSigns.tsx
+++ b/src/pages/GraduationSigns.tsx
@@ -15,6 +15,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import Layout from '@/components/Layout';
+import IndependenceDayNotice from '@/components/IndependenceDayNotice';
 import { useToast } from '@/components/ui/use-toast';
 import { useCartStore } from '@/store/cart';
 import type { MaterialKey } from '@/store/quote';
@@ -542,6 +543,12 @@ const GraduationSigns: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <div className="bg-white px-4 pt-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <IndependenceDayNotice />
+        </div>
+      </div>
 
       {/* Dynamic flow section */}
       <section id="choose-product-section" className="bg-white py-14 sm:py-20">

--- a/src/pages/PoliticalSigns.tsx
+++ b/src/pages/PoliticalSigns.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { Clock, Truck, ShieldCheck, CheckCircle, ArrowRight } from 'lucide-react';
 import Layout from '@/components/Layout';
+import IndependenceDayNotice from '@/components/IndependenceDayNotice';
 
 type ProductType = 'banner' | 'yard_sign' | 'car_magnet';
 
@@ -112,6 +113,12 @@ const PoliticalSigns: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <div className="bg-white px-4 pt-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <IndependenceDayNotice />
+        </div>
+      </div>
 
       <section id="choose-product" className="bg-white py-14 sm:py-16">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
### Motivation
- Inform customers of the Independence Day shipping schedule prominently on product pages so they see it before ordering. 
- Provide a single, easy-to-update message and reusable UI element that matches site branding and remains unobtrusive. 

### Description
- Add a reusable `IndependenceDayNotice` component at `src/components/IndependenceDayNotice.tsx` that exposes the message via `INDEPENDENCE_DAY_NOTICE` and includes subtle red/blue accents, a small flag icon, responsive layout, and an accessible `aria-label`. 
- Insert the notice near the top of product/order flows by importing and rendering it on the main builder and product pages: `src/pages/Design.tsx`, `src/pages/GoogleAdsBanner.tsx`, `src/pages/CategoryPage.tsx`, `src/pages/CityProductPage.tsx`, `src/pages/GraduationSigns.tsx`, and `src/pages/PoliticalSigns.tsx`. 
- Styling is Tailwind-based, responsive for mobile and desktop, visually subtle (rounded card, thin patriotic gradient/border, small decorative icon) and designed not to interfere with the quote/order form or product layout. 
- The message text is centralized for easy future edits or removal. 

### Testing
- `npm run lint` was attempted and failed because project dependencies are not installed and ESLint could not resolve `@eslint/js`. 
- `npm ci` was attempted and blocked because `package-lock.json` is out of sync with `package.json`. 
- `npm install` was attempted and failed with a `403 Forbidden` when fetching `netlify-cli`, preventing dependency installation. 
- `npm run build` was attempted and failed because dependencies are not installed and `vite` was not found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a415c595bbc8333b55ab1dda77c2ab2)